### PR TITLE
docs(research): afegir taula comparativa Schulze vs Borda, Condorcet, IRV

### DIFF
--- a/docs/research/ethereum.md
+++ b/docs/research/ethereum.md
@@ -1,0 +1,86 @@
+# Ethereum — Fonaments i rol en el projecte
+
+**ID de la tasca**: E1-US2-T3
+**Data**: 2026-05-01
+
+---
+
+## 1. Fonaments d'Ethereum
+
+### 1.1. Costos de _gas_
+
+A Ethereum, cada operació computacional consumeix una quantitat de **_gas_**, la unitat de mesura del cost de càlcul. El preu del _gas_ es denomina en _gwei_ (un miliardèsim d'ETH) i varia dinàmicament en funció de la demanda de la xarxa: quan hi ha congestió, el cost pot multiplicar-se per deu o per cent en qüestió de minuts.
+
+Amb EIP-1559 (desplegat l'agost de 2021), la tarifa es divideix en dues parts. Una **_base fee_** determinada automàticament per la xarxa i cremada per sempre (destruïda, no va a cap miner). Un **_priority fee_** (o _tip_) que el remitent afegeix voluntàriament per incentivar els validadors a incloure la seva transacció aviat.
+
+Una transacció senzilla d'ETH costa 21.000 unitats de _gas_. Una crida a un _smart contract_ complex pot costar entre 100.000 i diversos milions. A preu de _gas_ alt (50-200 _gwei_), operacions habituals com la verificació d'una prova zk-SNARK poden costar entre 1 € i 50 € per transacció. Per a un sistema de votació amb milions de vots, aquest cost fa inviable executar la lògica electoral directament a la L1 d'Ethereum.
+
+### 1.2. Temps de bloc i finalització
+
+Ethereum produeix un bloc cada **12 segons** (des de la Merge, setembre de 2022). Però un bloc confirmat no és un bloc final: la cadena pot reorganitzar-se si es produeix una bifurcació temporal.
+
+La **finalitat** a Ethereum es produeix amb el protocol **Gasper** (LMD-GHOST + Casper FFG). Un _checkpoint_ (cada 32 blocs, uns 6,4 minuts) es considera finalment "justificat" quan dos terços dels validadors hi estan d'acord, i "finalitzat" al següent _checkpoint_. La finalitat econòmica completa tarda entre **12 i 15 minuts** des que s'inclou una transacció.
+
+Comparat amb Algorand, que finalitza cada bloc en **~3,5 segons** amb finalitat immediata i irreversible (cap reorganització possible), el temps de finalitat d'Ethereum és entre 200 i 250 vegades superior. Per a un procés electoral on cada vot ha de quedar confirmat de manera definitiva, aquesta latència és acceptable per a l'ancoratge ocasional, però no per al flux de vots en temps real.
+
+### 1.3. Cadenes públiques vs. privades
+
+| Dimensió | Cadena pública (Ethereum/Algorand) | Cadena privada (permissionada) |
+|---|---|---|
+| Control d'accés | Obert, qualsevol pot llegir i escriure | Restringit a membres del consorci |
+| Verificació independent | Immediata, sense permís | Requereix accés al consorci |
+| Cost d'atac al consens | Milers de milions d'euros (L1) | Pressió política sobre uns pocs nodes |
+| Manteniment | Inexistent (la xarxa ja existeix) | Continu i costós |
+| Transparència | Total i pública | Limitada als membres |
+| Finalitat | Determinada pel protocol (de 3,5 s a 15 min) | Configurada pel consorci |
+
+Ethereum, com a cadena pública, ofereix el màxim de transparència i la verificació independent sense barreres. Qualsevol organisme internacional pot comprovar qualsevol transacció sense demanar permís a ningú. El preu d'aquest avantatge és el cost del _gas_ i la latència de finalitat.
+
+---
+
+## 2. Per què el projecte utilitza Ethereum únicament per a l'ancoratge
+
+### 2.1. La decisió central: Algorand per a la votació, Ethereum per al rastre
+
+El projecte adopta **Algorand** com a capa d'execució de tota la lògica electoral (vots, _nullifiers_, agregació homomòrfica, verificació de proves zk-SNARK, desxifrat dels _trustees_). La justificació detallada es desenvolupa a l'ADR 002. En resum: Algorand ofereix finalitat en 3,5 s, comissions de l'ordre de 0,001 ALGO (~0,0002 €), i les primitives criptogràfiques BN254 necessàries per a Groth16.
+
+Ethereum entra en escena per a una funció molt concreta i diferent: **ancorar proves d'integritat** dels resultats electorals en una xarxa de màxima difusió i reconeixement institucional global.
+
+### 2.2. Quin és el rol de l'ancoratge
+
+Quan una elecció es tanca i el recompte queda definitiu, es genera un **_digest_ criptogràfic** (un _hash_ SHA-256 o Poseidon) de tot l'estat electoral: els _ciphertexts_ agregats, les _shares_ dels _trustees_, el resultat en clar, i el guanyador. Aquest _digest_ s'envia en una transacció cap a un contracte d'Ethereum (o simplement a l'espai de dades d'una transacció normal).
+
+El resultat: existeix un registre permanent a Ethereum que diu, essencialment, "el dia D a l'hora H, l'elecció amb ID X tenia aquest _hash_ de resultat". Ningú pot alterar l'estat d'Algorand retroactivament per fabricar un resultat diferent sense que el _hash_ d'Ethereum deixi de coincidir.
+
+### 2.3. Per què no tornem a executar l'elecció a Ethereum
+
+Executar la lògica completa de votació a Ethereum és inviable per cinc raons estructurals:
+
+**Cost de _gas_ prohibitiu.** La verificació d'una prova Groth16 a Ethereum costa al voltant de 250.000 unitats de _gas_. A 50 _gwei_ i 3.000 $/ETH, cada vot costaria ~37,50 $. Per 100.000 votants: 3.750.000 $. Per als mateixos votants a Algorand: ~20 $. La diferència és de sis ordres de magnitud.
+
+**Latència de finalitat inadequada.** Una elecció ha d'oferir als votants confirmació immediata que el seu vot s'ha registrat. A Ethereum, la finalitat econòmica tarda 12-15 minuts. A Algorand, 3,5 segons. Durant una finestra electoral de 24 hores amb pics de trànsit, la cua de confirmació d'Ethereum es convertiria en un coll d'ampolla.
+
+**Primitives criptogràfiques.** Algorand té opcodes natius per a BN254 (la corba que necessita Groth16). Ethereum també té precompilats BN254 (EIP-197), però la integració amb les _boxes_ de gestió de _nullifiers_ i el _fee pooling_ atòmic per als _sponsors_ és molt més natural al model d'Algorand.
+
+**Cost d'infraestructura per als votants.** A Ethereum, cada votant hauria de pagar _gas_ directament (el mecanisme de patrocini atòmic d'Algorand no existeix a Ethereum de manera equivalent i simple). Delegar el pagament a un _relayer_ introdueix un intermediari de confiança addicional.
+
+**Sobirania electoral i risc de regulació.** Ethereum és la xarxa _smart contract_ més gran del món i, per tant, la més exposada a pressions regulatòries de grans potències. La dependència d'Ethereum per a l'execució de la lògica electoral concentraria el risc polític en un actor únic. Per a l'ancoratge, aquest risc és acceptable: un _hash_ és immutable un cop escrit, i si Ethereum patís una crisi, el registre ja existeix.
+
+### 2.4. L'ancoratge com a pont de confiança institucional
+
+Hi ha una raó no tècnica però important: **la reconeixibilitat institucional d'Ethereum**. Quan una elecció produeix un resultat i l'ancora a Ethereum, qualsevol auditor extern, fins i tot sense conèixer Algorand, pot verificar el _hash_ a Etherscan o a qualsevol explorador públic. La verificació del resultat es torna accessible a actors que no formin part de l'ecosistema Algorand.
+
+Algorand és la infraestructura tècnicament superior per a l'execució. Ethereum és el registre notarial global que el món institucional reconeix. El disseny aprofita el millor de cada cadena sense duplicar els costos de cap.
+
+---
+
+## Resum
+
+| Aspecte | Ethereum (ancoratge) | Algorand (execució) |
+|---|---|---|
+| Funció en el sistema | Registre notarial de resultats finals | Execució completa de la lògica electoral |
+| Cost per operació | 1–50 € (per ancoratge ocasional: acceptable) | ~0,0002 € (per cada vot: negligible) |
+| Temps de finalitat | 12-15 minuts | 3,5 segons |
+| Operacions per elecció | 1 (ancorar el _digest_ final) | Milions (un per vot) |
+| Primitives zk-SNARK | Precompilats BN254 (EIP-197) | Opcodes BN254 natius |
+| Reconeixibilitat institucional | Màxima (global) | Alta però menor |

--- a/docs/research/voting-methods-comparison.md
+++ b/docs/research/voting-methods-comparison.md
@@ -1,0 +1,88 @@
+# Comparativa de mètodes de votació ordinal
+
+**ID de la tasca**: E1-US3-T2
+**Data**: 2026-05-01
+
+---
+
+## 1. Propietats avaluades
+
+Abans de comparar, cal definir les cinc propietats que s'analitzen:
+
+**Monotonicitat**: Un mètode és monòton si augmentar el suport a un candidat (sense canviar res més) mai pot perjudicar-lo. La violació significa que votar «més fort» per un candidat pot fer-lo perdre.
+
+**Independència de clons** (_clone independence_): Un mètode és independent de clons si afegir un candidat quasi idèntic (un _clon_) a la carrera no canvia el resultat final. Sense aquesta propietat, un partit pot manipular l'elecció dividint candidats o, a l'inrevés, un candidat popular pot ser «envoltat» de clons per repartir-li el suport.
+
+**Consistència amb Condorcet** (_Condorcet consistency_): Si existeix un guanyador de Condorcet (un candidat que guanya totes les comparacions per parelles), el mètode l'ha d'elegir. No tots els mètodes garanteixen aquest criteri.
+
+**Simetria per inversió** (_reversal symmetry_): Si s'inverteix l'ordre de totes les preferències de tots els votants, el guanyador original hauria de perdre (o almenys no guanyar de nou). Assegura que el sistema distingeix entre consens positiu i consens negatiu.
+
+**Complexitat computacional**: Temps i recursos necessaris per calcular el guanyador. En el context d'un _smart contract_ a Algorand, la complexitat afecta directament el cost en comissions i la viabilitat d'executar l'escrutini on-chain.
+
+---
+
+## 2. Taula comparativa
+
+| Propietat | Schulze | Borda | Condorcet (pur) | IRV (_instant-runoff_) |
+|---|---|---|---|---|
+| Monotonicitat | Sí | Sí | Sí | **No** |
+| Independència de clons | Sí | **No** | Sí (amb matriu) | Sí (elimina per ronda) |
+| Consistència amb Condorcet | Sí | **No** | Sí (per definició) | **No** |
+| Simetria per inversió | Sí | **No** | No garantida | **No** |
+| Complexitat | O(n³) sobre candidats | O(n·m) | O(n²·m) | O(n·m·r) |
+
+Llegenda: _n_ = nombre de candidats, _m_ = nombre de votants, _r_ = nombre de rondes d'eliminació.
+
+---
+
+## 3. Anàlisi per mètode
+
+### 3.1. Schulze
+
+El mètode de Schulze construeix una matriu de comparació per parelles a partir dels rangs dels votants i, a continuació, calcula la matriu de _camins més forts_ (Floyd-Warshall). El guanyador és el candidat que té el camí més fort cap a tots els altres.
+
+Schulze compleix les quatre propietats de qualitat de la taula. Això el converteix en l'estàndard acadèmic entre els mètodes de Condorcet i en la tria justificada per aquest projecte.
+
+El cost computacional és O(n³) sobre el nombre de candidats, que en eleccions típiques (5–20 candidats) és trivial. Per a un _smart contract_, la matriu de camins es pot precomputar fora de la cadena i simplement verificar on-chain.
+
+### 3.2. Borda
+
+Cada votant assigna punts decreixents als candidats per ordre de preferència. El guanyador és qui acumula més punts. És simple d'entendre i d'explicar, però té dues debilitats crítiques:
+
+- **No satisfà Condorcet**: un candidat que guanya totes les comparacions per parelles pot perdre amb Borda si els seus oponents acumulen molts punts per ser consistentment en segona o tercera posició.
+- **Vulnerable a la manipulació per clons**: afegir candidats semblants al guanyador pot desplaçar els seus punts i canviar el resultat.
+
+### 3.3. Condorcet (pur)
+
+El «mètode de Condorcet» en sentit estricte és un criteri, no un mètode complet: elegeix el guanyador de Condorcet si n'hi ha un. El problema és que en eleccions reals pot no existir cap guanyador de Condorcet (paradoxa de Condorcet / cicles de preferències). En aquest cas, el mètode pur no dóna cap resposta sense una regla de desempat addicional.
+
+Schulze és essencialment un mètode de Condorcet amb una regla de desempat ben definida (camins més forts), que resol els cicles de manera consistent i monòtona.
+
+### 3.4. IRV (_Instant-Runoff Voting_)
+
+L'IRV elimina iterativament el candidat amb menys primeres preferències fins que un candidat obté majoria. És el mètode usat per a les eleccions nacionals d'Austràlia i per moltes administracions locals als EUA i al RU.
+
+Malgrat la seva popularitat, l'IRV té dues debilitats importants per al projecte:
+
+- **No és monòton**: en alguns escenaris, obtenir més suport pot fer perdre un candidat. Això és contraintuïtiu i difícil de justificar públicament.
+- **No satisfà Condorcet**: el guanyador de Condorcet no és necessàriament l'elegit per IRV.
+
+Per a un sistema de votació que vol ser verificable i justificable acadèmicament, la no-monotonicitat de l'IRV és un obstacle important.
+
+---
+
+## 4. Justificació de l'elecció de Schulze
+
+Schulze és l'únic mètode de la taula que compleix simultàniament les quatre propietats de qualitat. A més:
+
+- Té una implementació algorítmica clara (Floyd-Warshall sobre la matriu de comparació per parelles).
+- La literatura acadèmica el documenta àmpliament (Schulze, 2011).
+- Permet precomputació off-chain amb verificació on-chain, cosa compatible amb l'arquitectura del projecte.
+- L'article original descriu la seva resistència a la manipulació estratègica i la seva aplicació a votació electrònica.
+
+---
+
+## Fonts
+
+- Schulze, M. (2011). «A new monotonic, clone-independent, reversal symmetric, and Condorcet-consistent single-winner election method». _Social Choice and Welfare_, 36(2), 267–303.
+- Viquipèdia. «Comparison of electoral systems». [https://en.wikipedia.org/wiki/Comparison_of_electoral_systems](https://en.wikipedia.org/wiki/Comparison_of_electoral_systems)


### PR DESCRIPTION
## Descripció del canvi

Afegeix el document `/docs/research/voting-methods-comparison.md` amb una taula comparativa dels quatre mètodes de votació ordinal principals (Schulze, Borda, Condorcet pur i IRV) respecte a cinc propietats: monotonicitat, independència de clons, consistència amb Condorcet, simetria per inversió i complexitat computacional. S'explica per a cada mètode on falla i per quin motiu Schulze és l'elecció adequada per al projecte.

## Tipus de canvi

- [ ] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [x] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #74

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal