### PR TITLE
feat(client): schema de la proposta amb tots els errors configurats

### DIFF
--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -1,0 +1,18 @@
+{
+  "brand": "Demochain",
+  "errors": {
+    "proposal": {
+      "empty-title": "El títol no pot estar buit",
+      "empty-description": "La descripció no pot estar buida",
+      "starting-too-soon": "La data d'inici ha de ser almenys 3 dies en el futur",
+      "small-voting-window": "La finestra de votació ha de durar almenys 1 dia",
+      "too-few-options": "Cal afegir almenys 2 opcions",
+      "empty-options": "Cap opció pot estar buida",
+      "duplicated-options": "Hi ha opcions duplicades"
+    },
+    "wallet": {
+      "rejected": "Has cancel·lat la signatura",
+      "network": "Error de xarxa. Torna-ho a intentar."
+    }
+  }
+}

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -1,0 +1,18 @@
+{
+  "brand": "Demochain",
+  "errors": {
+    "proposal": {
+      "empty-title": "Title cannot be empty",
+      "empty-description": "Description cannot be empty",
+      "starting-too-soon": "Start date must be at least 3 days in the future",
+      "small-voting-window": "Voting window must last at least 1 day",
+      "too-few-options": "At least 2 options are required",
+      "empty-options": "No option can be empty",
+      "duplicated-options": "There are duplicate options"
+    },
+    "wallet": {
+      "rejected": "You cancelled the signature",
+      "network": "Network error. Please try again."
+    }
+  }
+}

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -1,0 +1,18 @@
+{
+  "brand": "Demochain",
+  "errors": {
+    "proposal": {
+      "empty-title": "El título no puede estar vacío",
+      "empty-description": "La descripción no puede estar vacía",
+      "starting-too-soon": "La fecha de inicio debe ser al menos 3 días en el futuro",
+      "small-voting-window": "La ventana de votación debe durar al menos 1 día",
+      "too-few-options": "Se necesitan al menos 2 opciones",
+      "empty-options": "Ninguna opción puede estar vacía",
+      "duplicated-options": "Hay opciones duplicadas"
+    },
+    "wallet": {
+      "rejected": "Has cancelado la firma",
+      "network": "Error de red. Inténtalo de nuevo."
+    }
+  }
+}

--- a/client/src/schemas/proposal.test.ts
+++ b/client/src/schemas/proposal.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'bun:test';
+import { basicsSchema, datesSchema, optionsSchema, proposalSchema } from './proposal';
+
+const APPROVAL_BUFFER_DAYS = 3;
+
+function futureDate(daysFromNow: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function errorCodes(result: { success: boolean; error?: { issues: { message: string }[] } }): string[] {
+  if (result.success || !result.error) return [];
+  return result.error.issues.map((i) => i.message);
+}
+
+describe('basicsSchema', () => {
+  it('passes with non-empty title and description', () => {
+    const result = basicsSchema.safeParse({ title: 'My proposal', description: 'Some detail' });
+    expect(result.success).toBe(true);
+  });
+
+  it('fails with empty title → proposal.empty-title', () => {
+    const result = basicsSchema.safeParse({ title: '', description: 'Some detail' });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-title');
+  });
+
+  it('fails with whitespace-only title → proposal.empty-title', () => {
+    const result = basicsSchema.safeParse({ title: '   ', description: 'Some detail' });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-title');
+  });
+
+  it('fails with empty description → proposal.empty-description', () => {
+    const result = basicsSchema.safeParse({ title: 'My proposal', description: '' });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-description');
+  });
+
+  it('fails with whitespace-only description → proposal.empty-description', () => {
+    const result = basicsSchema.safeParse({ title: 'My proposal', description: '  ' });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-description');
+  });
+});
+
+describe('datesSchema', () => {
+  it('passes when start is 4+ days away and end is 2+ days after start', () => {
+    const result = datesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 3),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('fails when start is less than 3 days from now → proposal.starting-too-soon', () => {
+    const result = datesSchema.safeParse({
+      startDate: futureDate(1),
+      endDate: futureDate(5),
+    });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.starting-too-soon');
+  });
+
+  it('fails when end equals start → proposal.small-voting-window', () => {
+    const start = futureDate(APPROVAL_BUFFER_DAYS + 1);
+    const result = datesSchema.safeParse({
+      startDate: start,
+      endDate: new Date(start),
+    });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.small-voting-window');
+  });
+
+  it('fails when end is exactly 1 day after start → proposal.small-voting-window', () => {
+    const result = datesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 2),
+    });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.small-voting-window');
+  });
+
+  it('passes when end is more than 1 day after start', () => {
+    const result = datesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 4),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('optionsSchema', () => {
+  it('passes with 2 non-empty unique options', () => {
+    const result = optionsSchema.safeParse({ options: ['Option A', 'Option B'] });
+    expect(result.success).toBe(true);
+  });
+
+  it('fails with only 1 option → proposal.too-few-options', () => {
+    const result = optionsSchema.safeParse({ options: ['Only one'] });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.too-few-options');
+  });
+
+  it('fails with 0 options → proposal.too-few-options', () => {
+    const result = optionsSchema.safeParse({ options: [] });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.too-few-options');
+  });
+
+  it('fails with an empty option → proposal.empty-options', () => {
+    const result = optionsSchema.safeParse({ options: ['Option A', 'Option B', ''] });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-options');
+  });
+
+  it('fails with a whitespace-only option → proposal.empty-options', () => {
+    const result = optionsSchema.safeParse({ options: ['Option A', 'Option B', '   '] });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.empty-options');
+  });
+
+  it('fails with duplicate options (case-insensitive) → proposal.duplicated-options', () => {
+    const result = optionsSchema.safeParse({ options: ['Option A', 'option a'] });
+    expect(result.success).toBe(false);
+    expect(errorCodes(result)).toContain('proposal.duplicated-options');
+  });
+
+  it('passes with 3 unique options', () => {
+    const result = optionsSchema.safeParse({ options: ['A', 'B', 'C'] });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('proposalSchema (full)', () => {
+  it('passes with all valid data', () => {
+    const result = proposalSchema.safeParse({
+      title: 'My Proposal',
+      description: 'A detailed description',
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 3),
+      options: ['Option A', 'Option B'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('reports all errors when everything is invalid', () => {
+    const result = proposalSchema.safeParse({
+      title: '',
+      description: '',
+      startDate: futureDate(1),
+      endDate: futureDate(1),
+      options: ['only'],
+    });
+    expect(result.success).toBe(false);
+    const codes = errorCodes(result);
+    expect(codes).toContain('proposal.empty-title');
+    expect(codes).toContain('proposal.empty-description');
+    expect(codes).toContain('proposal.starting-too-soon');
+    expect(codes).toContain('proposal.too-few-options');
+  });
+});

--- a/client/src/schemas/proposal.ts
+++ b/client/src/schemas/proposal.ts
@@ -1,0 +1,61 @@
+import * as z from 'zod';
+
+const APPROVAL_BUFFER_DAYS = 3;
+
+const MS_PER_DAY = 86_400_000;
+
+function minStartDate(): Date {
+  return new Date(Date.now() + APPROVAL_BUFFER_DAYS * MS_PER_DAY);
+}
+
+export const basicsSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, { message: 'proposal.empty-title' }),
+  description: z
+    .string()
+    .trim()
+    .min(1, { message: 'proposal.empty-description' }),
+});
+
+export const datesSchema = z
+  .object({
+    startDate: z.date(),
+    endDate: z.date(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.startDate < minStartDate()) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'proposal.starting-too-soon',
+        path: ['startDate'],
+      });
+    }
+
+    const startPlusOne = new Date(data.startDate);
+    startPlusOne.setDate(startPlusOne.getDate() + 1);
+
+    if (data.endDate <= startPlusOne) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'proposal.small-voting-window',
+        path: ['endDate'],
+      });
+    }
+  });
+
+export const optionsSchema = z.object({
+  options: z
+    .array(z.string().trim().min(1, { message: 'proposal.empty-options' }))
+    .min(2, { message: 'proposal.too-few-options' })
+    .refine(
+      (opts) => {
+        const lower = opts.map((o) => o.toLowerCase());
+        return new Set(lower).size === lower.length;
+      },
+      { message: 'proposal.duplicated-options' },
+    ),
+});
+
+export const proposalSchema = basicsSchema.and(datesSchema).and(optionsSchema);


### PR DESCRIPTION
## Descripció del canvi

S'ha configurat l'*schema* de `zod` per crear una proposta.
S'han configurat els errors definits a #311 i la traducció d'aquests a anglès, català i castellà.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [x] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

<!-- Utilitza "Closes #N" per tancar automàticament una issue en fer merge -->

Closes #313

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
