### PR TITLE
feat(contract): Implementar la creació d'organitzacions

### DIFF
--- a/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
+++ b/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
@@ -7,13 +7,15 @@ class Organization(arc4.Struct):
     description: arc4.String
     admin: arc4.Address
 
-class Demochain(ARC4Contract):
 
+class Demochain(ARC4Contract):
     def __init__(self) -> None:
         self.org_id = arc4.UInt64(0)
         self.organizations = BoxMap(arc4.UInt64, Organization, key_prefix="org_")
         self.organization_names = BoxMap(arc4.String, arc4.Bool, key_prefix="on_")
-        self.census = BoxMap(arc4.Tuple[arc4.UInt64, arc4.Address], arc4.Bool, key_prefix="cen_")
+        self.census = BoxMap(
+            arc4.Tuple[arc4.UInt64, arc4.Address], arc4.Bool, key_prefix="cen_"
+        )
 
     @abimethod()
     def create_org(self, name: arc4.String, description: arc4.String) -> arc4.UInt64:
@@ -30,7 +32,9 @@ class Demochain(ARC4Contract):
             arc4.Address(Txn.sender),
         )
         self.organization_names[name] = arc4.Bool(True)
-        self.census[arc4.Tuple((self.org_id, arc4.Address(Txn.sender)))] = arc4.Bool(True)
+        self.census[arc4.Tuple((self.org_id, arc4.Address(Txn.sender)))] = arc4.Bool(
+            True
+        )
 
         return self.org_id
 

--- a/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
+++ b/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
@@ -1,8 +1,44 @@
-from algopy import ARC4Contract, String
+from algopy import ARC4Contract, arc4, BoxMap, Txn, urange, op
 from algopy.arc4 import abimethod
 
 
+class Organization(arc4.Struct):
+    name: arc4.String
+    description: arc4.String
+    admin: arc4.Address
+
 class Demochain(ARC4Contract):
+
+    def __init__(self) -> None:
+        self.org_id = arc4.UInt64(0)
+        self.organizations = BoxMap(arc4.UInt64, Organization, key_prefix="org_")
+        self.organization_names = BoxMap(arc4.String, arc4.Bool, key_prefix="on_")
+        self.census = BoxMap(arc4.Tuple[arc4.UInt64, arc4.Address], arc4.Bool, key_prefix="cen_")
+
     @abimethod()
-    def hello(self, name: String) -> String:
-        return "Hello, " + name
+    def create_org(self, name: arc4.String, description: arc4.String) -> arc4.UInt64:
+        """Method for creating an organization"""
+        assert not self._is_blank(name), "org.empty-name"
+        assert not self._is_blank(description), "org.empty-description"
+        assert name not in self.organization_names, "org.already-exists"
+
+        self.org_id = arc4.UInt64(self.org_id.native + 1)
+
+        self.organizations[self.org_id] = Organization(
+            name,
+            description,
+            arc4.Address(Txn.sender),
+        )
+        self.organization_names[name] = arc4.Bool(True)
+        self.census[arc4.Tuple((self.org_id, arc4.Address(Txn.sender)))] = arc4.Bool(True)
+
+        return self.org_id
+
+    def _is_blank(self, s: arc4.String) -> bool:
+        b = s.native.bytes
+        if b.length == 0:
+            return True
+        for i in urange(b.length):
+            if op.getbyte(b, i) != 32:
+                return False
+        return True

--- a/voting-contract/projects/demochain/tests/organiation_unit_test.py
+++ b/voting-contract/projects/demochain/tests/organiation_unit_test.py
@@ -1,0 +1,97 @@
+from collections.abc import Iterator
+
+import pytest
+from algopy_testing import AlgopyTestContext, algopy_testing_context
+from algopy import arc4
+
+from smart_contracts.demochain.contract import Demochain
+
+
+@pytest.fixture()
+def context() -> Iterator[AlgopyTestContext]:
+    with algopy_testing_context() as ctx:
+        yield ctx
+
+
+@pytest.fixture()
+def contract(context: AlgopyTestContext) -> Demochain:
+    return Demochain()
+
+
+# --- Tests dels criteris d'acceptació ---
+
+def test_create_org_with_valid_params_returns_id(context: AlgopyTestContext, contract: Demochain) -> None:
+    org_id = contract.create_org(arc4.String("Demochain"), arc4.String("Sistema de votació"))
+    assert org_id == arc4.UInt64(1)
+
+
+def test_create_org_second_call_returns_incremental_id(context: AlgopyTestContext, contract: Demochain) -> None:
+    id1 = contract.create_org(arc4.String("Org 1"), context.any.arc4.string(n=256))
+    id2 = contract.create_org(arc4.String("Org 2"), context.any.arc4.string(n=128))
+
+    assert id1 == arc4.UInt64(1)
+    assert id2 == arc4.UInt64(2)
+
+
+def test_create_org_stores_org_on_chain(context: AlgopyTestContext, contract: Demochain) -> None:
+    name = arc4.String("Demochain")
+    description = arc4.String("Voting system")
+    org_id = contract.create_org(name, description)
+    org = contract.organizations[org_id]
+
+    assert org.name == name
+    assert org.description == description
+
+
+def test_create_org_stores_caller_as_admin(context: AlgopyTestContext, contract: Demochain) -> None:
+    sender = context.any.account()
+
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        org_id = contract.create_org(arc4.String("Invented organization"), arc4.String("Description"))
+
+    assert contract.organizations[org_id].admin == arc4.Address(sender)
+
+
+def test_create_org_registers_name_in_names_map(contract: Demochain) -> None:
+    name = arc4.String("Demochain")
+    contract.create_org(name, arc4.String("Voting system"))
+
+    assert name in contract.organization_names
+    assert contract.organization_names[name] == arc4.Bool(True)
+
+
+def test_create_org_adds_creator_to_census(context: AlgopyTestContext, contract: Demochain) -> None:
+    sender = context.any.account()
+
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        org_id = contract.create_org(arc4.String("Org census"), arc4.String("Description"))
+
+    census_key = arc4.Tuple((org_id, arc4.Address(sender)))
+    assert census_key in contract.census
+
+
+def test_create_org_empty_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+    with pytest.raises(AssertionError, match="org.empty-name"):
+        contract.create_org(arc4.String(""), arc4.String("Valid description"))
+
+
+def test_create_org_blank_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+    with pytest.raises(AssertionError, match="org.empty-name"):
+        contract.create_org(arc4.String("   "), arc4.String("Valid description"))
+
+
+def test_create_org_empty_description_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+    with pytest.raises(AssertionError, match="org.empty-description"):
+        contract.create_org(arc4.String("Nom vàlid"), arc4.String(""))
+
+
+def test_create_org_blank_description_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+    with pytest.raises(AssertionError, match="org.empty-description"):
+        contract.create_org(arc4.String("Nom vàlid"), arc4.String("   "))
+
+
+def test_create_org_duplicate_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+    contract.create_org(arc4.String("Demochain"), arc4.String("Primera"))
+
+    with pytest.raises(AssertionError, match="org.already-exists"):
+        contract.create_org(arc4.String("Demochain"), arc4.String("Duplicada"))

--- a/voting-contract/projects/demochain/tests/organization_unit_test.py
+++ b/voting-contract/projects/demochain/tests/organization_unit_test.py
@@ -20,12 +20,19 @@ def contract(context: AlgopyTestContext) -> Demochain:
 
 # --- Tests dels criteris d'acceptació ---
 
-def test_create_org_with_valid_params_returns_id(context: AlgopyTestContext, contract: Demochain) -> None:
-    org_id = contract.create_org(arc4.String("Demochain"), arc4.String("Sistema de votació"))
+
+def test_create_org_with_valid_params_returns_id(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    org_id = contract.create_org(
+        arc4.String("Demochain"), arc4.String("Sistema de votació")
+    )
     assert org_id == arc4.UInt64(1)
 
 
-def test_create_org_second_call_returns_incremental_id(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_second_call_returns_incremental_id(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     id1 = contract.create_org(arc4.String("Org 1"), context.any.arc4.string(n=256))
     id2 = contract.create_org(arc4.String("Org 2"), context.any.arc4.string(n=128))
 
@@ -33,7 +40,9 @@ def test_create_org_second_call_returns_incremental_id(context: AlgopyTestContex
     assert id2 == arc4.UInt64(2)
 
 
-def test_create_org_stores_org_on_chain(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_stores_org_on_chain(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     name = arc4.String("Demochain")
     description = arc4.String("Voting system")
     org_id = contract.create_org(name, description)
@@ -43,11 +52,15 @@ def test_create_org_stores_org_on_chain(context: AlgopyTestContext, contract: De
     assert org.description == description
 
 
-def test_create_org_stores_caller_as_admin(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_stores_caller_as_admin(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     sender = context.any.account()
 
     with context.txn.create_group(active_txn_overrides={"sender": sender}):
-        org_id = contract.create_org(arc4.String("Invented organization"), arc4.String("Description"))
+        org_id = contract.create_org(
+            arc4.String("Invented organization"), arc4.String("Description")
+        )
 
     assert contract.organizations[org_id].admin == arc4.Address(sender)
 
@@ -60,37 +73,51 @@ def test_create_org_registers_name_in_names_map(contract: Demochain) -> None:
     assert contract.organization_names[name] == arc4.Bool(True)
 
 
-def test_create_org_adds_creator_to_census(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_adds_creator_to_census(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     sender = context.any.account()
 
     with context.txn.create_group(active_txn_overrides={"sender": sender}):
-        org_id = contract.create_org(arc4.String("Org census"), arc4.String("Description"))
+        org_id = contract.create_org(
+            arc4.String("Org census"), arc4.String("Description")
+        )
 
     census_key = arc4.Tuple((org_id, arc4.Address(sender)))
     assert census_key in contract.census
 
 
-def test_create_org_empty_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_empty_name_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     with pytest.raises(AssertionError, match="org.empty-name"):
         contract.create_org(arc4.String(""), arc4.String("Valid description"))
 
 
-def test_create_org_blank_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_blank_name_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     with pytest.raises(AssertionError, match="org.empty-name"):
         contract.create_org(arc4.String("   "), arc4.String("Valid description"))
 
 
-def test_create_org_empty_description_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_empty_description_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     with pytest.raises(AssertionError, match="org.empty-description"):
         contract.create_org(arc4.String("Nom vàlid"), arc4.String(""))
 
 
-def test_create_org_blank_description_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_blank_description_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     with pytest.raises(AssertionError, match="org.empty-description"):
         contract.create_org(arc4.String("Nom vàlid"), arc4.String("   "))
 
 
-def test_create_org_duplicate_name_raises_error(context: AlgopyTestContext, contract: Demochain) -> None:
+def test_create_org_duplicate_name_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
     contract.create_org(arc4.String("Demochain"), arc4.String("Primera"))
 
     with pytest.raises(AssertionError, match="org.already-exists"):


### PR DESCRIPTION
## Descripció del canvi

Implementar la creació d'organitzacions. Crea una organització amb un nom, una descripció i una direcció que és la de l'administrador de l'organització (el que crea l'organització).

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #392 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
