### PR TITLE
feat(voting-contract): Afegir funció per crear propostes

### DIFF
--- a/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
+++ b/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
@@ -18,6 +18,7 @@ class Proposal(arc4.Struct):
     title: arc4.String
     description: arc4.String
     options: arc4.DynamicArray[arc4.String]
+    org_id: arc4.UInt64
     creator: arc4.Address
     starting_date: arc4.UInt64
     ending_date: arc4.UInt64
@@ -103,12 +104,17 @@ class Demochain(ARC4Contract):
     @abimethod()
     def create_proposal(
         self,
+        org_id: arc4.UInt64,
         title: arc4.String,
         description: arc4.String,
         options: arc4.DynamicArray[arc4.String],
         start_date: arc4.UInt64,
         ending_date: arc4.UInt64,
     ) -> arc4.UInt64:
+        assert org_id in self.organizations, "org.not-found"
+        assert arc4.Tuple((org_id, arc4.Address(Txn.sender))) in self.census, (
+            "proposal.unauthorized"
+        )
         assert not self._is_blank(title), "proposal.empty-title"
         assert not self._is_blank(description), "proposal.empty-description"
         assert start_date.as_uint64() >= Global.latest_timestamp + MIN_START_ADVANCE, (
@@ -130,6 +136,7 @@ class Demochain(ARC4Contract):
             title,
             description,
             options.copy(),
+            org_id,
             arc4.Address(Txn.sender),
             start_date,
             ending_date,

--- a/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
+++ b/voting-contract/projects/demochain/smart_contracts/demochain/contract.py
@@ -4,11 +4,23 @@ from algopy.arc4 import abimethod
 # Max addresses per batch call: 8 box slots − 1 reserved for `organizations`
 MAX_CENSUS_BATCH = 7
 
+MIN_START_ADVANCE = 3 * 24 * 60 * 60  # 3 dies en segons
+MIN_VOTING_WINDOW = 24 * 60 * 60  # 1 dia en segons
+
 
 class Organization(arc4.Struct):
     name: arc4.String
     description: arc4.String
     admin: arc4.Address
+
+
+class Proposal(arc4.Struct):
+    title: arc4.String
+    description: arc4.String
+    options: arc4.DynamicArray[arc4.String]
+    creator: arc4.Address
+    starting_date: arc4.UInt64
+    ending_date: arc4.UInt64
 
 
 class Demochain(ARC4Contract):
@@ -19,6 +31,9 @@ class Demochain(ARC4Contract):
         self.census = BoxMap(
             arc4.Tuple[arc4.UInt64, arc4.Address], arc4.Bool, key_prefix="cen_"
         )
+
+        self.proposal_id = arc4.UInt64(0)
+        self.proposals = BoxMap(arc4.UInt64, Proposal, key_prefix="pr_")
 
     @abimethod()
     def create_org(self, name: arc4.String, description: arc4.String) -> arc4.UInt64:
@@ -84,6 +99,43 @@ class Demochain(ARC4Contract):
     def is_in_census(self, org_id: arc4.UInt64, address: arc4.Address) -> arc4.Bool:
         key = arc4.Tuple((org_id, address))
         return arc4.Bool(key in self.census)
+
+    @abimethod()
+    def create_proposal(
+        self,
+        title: arc4.String,
+        description: arc4.String,
+        options: arc4.DynamicArray[arc4.String],
+        start_date: arc4.UInt64,
+        ending_date: arc4.UInt64,
+    ) -> arc4.UInt64:
+        assert not self._is_blank(title), "proposal.empty-title"
+        assert not self._is_blank(description), "proposal.empty-description"
+        assert start_date.as_uint64() >= Global.latest_timestamp + MIN_START_ADVANCE, (
+            "proposal.starting-too-soon"
+        )
+        assert ending_date.as_uint64() >= start_date.as_uint64() + MIN_VOTING_WINDOW, (
+            "proposal.small-voting-window"
+        )
+        assert options.length >= 2, "proposal.too-few-options"
+
+        for i in urange(options.length):
+            opt_i = options[i]
+            assert not self._is_blank(opt_i), "proposal.empty-options"
+            for j in urange(i + 1, options.length):
+                assert opt_i.bytes != options[j].bytes, "proposal.duplicated-options"
+
+        self.proposal_id = arc4.UInt64(self.proposal_id.as_uint64() + 1)
+        self.proposals[self.proposal_id] = Proposal(
+            title,
+            description,
+            options.copy(),
+            arc4.Address(Txn.sender),
+            start_date,
+            ending_date,
+        )
+
+        return self.proposal_id
 
     def _is_blank(self, s: arc4.String) -> bool:
         b = s.native.bytes

--- a/voting-contract/projects/demochain/tests/proposal_unit_test.py
+++ b/voting-contract/projects/demochain/tests/proposal_unit_test.py
@@ -1,0 +1,240 @@
+from collections.abc import Iterator
+
+import pytest
+from algopy_testing import AlgopyTestContext, algopy_testing_context
+from algopy import arc4
+
+from smart_contracts.demochain.contract import (
+    Demochain,
+    MIN_START_ADVANCE,
+    MIN_VOTING_WINDOW,
+)
+
+NOW = 1_000_000_000
+
+VALID_START = NOW + MIN_START_ADVANCE + MIN_VOTING_WINDOW  # 4 dies des d'ara
+VALID_END = VALID_START + MIN_VOTING_WINDOW
+
+
+@pytest.fixture()
+def context() -> Iterator[AlgopyTestContext]:
+    with algopy_testing_context() as ctx:
+        ctx.ledger.patch_global_fields(latest_timestamp=NOW)
+        yield ctx
+
+
+@pytest.fixture()
+def contract(context: AlgopyTestContext) -> Demochain:
+    return Demochain()
+
+
+# --- Tests dels criteris d'acceptació ---
+
+
+def test_create_proposal_with_valid_params_returns_id(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    proposal_id = contract.create_proposal(
+        arc4.String("Títol"),
+        arc4.String("Descripció"),
+        arc4.DynamicArray(arc4.String("Opció A"), arc4.String("Opció B")),
+        arc4.UInt64(VALID_START),
+        arc4.UInt64(VALID_END),
+    )
+    assert proposal_id == arc4.UInt64(1)
+
+
+def test_create_proposal_second_call_returns_incremental_id(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    options = arc4.DynamicArray(arc4.String("Sí"), arc4.String("No"))
+    id1 = contract.create_proposal(
+        arc4.String("Proposta 1"),
+        arc4.String("Descripció 1"),
+        options,
+        arc4.UInt64(VALID_START),
+        arc4.UInt64(VALID_END),
+    )
+    id2 = contract.create_proposal(
+        arc4.String("Proposta 2"),
+        arc4.String("Descripció 2"),
+        options,
+        arc4.UInt64(VALID_START),
+        arc4.UInt64(VALID_END),
+    )
+    assert id1 == arc4.UInt64(1)
+    assert id2 == arc4.UInt64(2)
+
+
+def test_create_proposal_stores_proposal_on_chain(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    title = arc4.String("Títol")
+    description = arc4.String("Descripció")
+
+    proposal_id = contract.create_proposal(
+        title,
+        description,
+        arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+        arc4.UInt64(VALID_START),
+        arc4.UInt64(VALID_END),
+    )
+    proposal = contract.proposals[proposal_id]
+
+    assert proposal.title == title
+    assert proposal.description == description
+    assert proposal.starting_date == arc4.UInt64(VALID_START)
+    assert proposal.ending_date == arc4.UInt64(VALID_END)
+
+
+def test_create_proposal_stores_creator(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    sender = context.any.account()
+
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        proposal_id = contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+    assert contract.proposals[proposal_id].creator == arc4.Address(sender)
+
+
+def test_create_proposal_starting_too_soon_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    too_soon = arc4.UInt64(
+        NOW + MIN_VOTING_WINDOW
+    )  # només 1 dia d'antelació, cal mínim 3
+    with pytest.raises(AssertionError, match="proposal.starting-too-soon"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            too_soon,
+            arc4.UInt64(NOW + MIN_VOTING_WINDOW * 2),
+        )
+
+
+def test_create_proposal_small_voting_window_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    short_end = arc4.UInt64(
+        VALID_START + MIN_VOTING_WINDOW - 1
+    )  # 1 segon per sota del mínim
+    with pytest.raises(AssertionError, match="proposal.small-voting-window"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            short_end,
+        )
+
+
+def test_create_proposal_too_few_options_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.too-few-options"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Única opció")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_empty_option_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-options"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Opció A"), arc4.String("")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_blank_option_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-options"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Opció A"), arc4.String("   ")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_duplicated_options_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.duplicated-options"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Igual"), arc4.String("Igual")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_empty_title_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-title"):
+        contract.create_proposal(
+            arc4.String(""),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_blank_title_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-title"):
+        contract.create_proposal(
+            arc4.String("   "),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_empty_description_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-description"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String(""),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+
+
+def test_create_proposal_blank_description_raises_error(
+    context: AlgopyTestContext, contract: Demochain
+) -> None:
+    with pytest.raises(AssertionError, match="proposal.empty-description"):
+        contract.create_proposal(
+            arc4.String("Títol"),
+            arc4.String("   "),
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )

--- a/voting-contract/projects/demochain/tests/proposal_unit_test.py
+++ b/voting-contract/projects/demochain/tests/proposal_unit_test.py
@@ -28,59 +28,79 @@ def contract(context: AlgopyTestContext) -> Demochain:
     return Demochain()
 
 
+@pytest.fixture()
+def org_setup(context: AlgopyTestContext, contract: Demochain):
+    """Crea una org i retorna (sender, org_id). El sender queda al cens com a admin."""
+    sender = context.any.account()
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        org_id = contract.create_org(arc4.String("Org"), arc4.String("Descripció"))
+    return sender, org_id
+
+
 # --- Tests dels criteris d'acceptació ---
 
 
 def test_create_proposal_with_valid_params_returns_id(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    proposal_id = contract.create_proposal(
-        arc4.String("Títol"),
-        arc4.String("Descripció"),
-        arc4.DynamicArray(arc4.String("Opció A"), arc4.String("Opció B")),
-        arc4.UInt64(VALID_START),
-        arc4.UInt64(VALID_END),
-    )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        proposal_id = contract.create_proposal(
+            org_id,
+            arc4.String("Títol"),
+            arc4.String("Descripció"),
+            arc4.DynamicArray(arc4.String("Opció A"), arc4.String("Opció B")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
     assert proposal_id == arc4.UInt64(1)
 
 
 def test_create_proposal_second_call_returns_incremental_id(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
+    sender, org_id = org_setup
     options = arc4.DynamicArray(arc4.String("Sí"), arc4.String("No"))
-    id1 = contract.create_proposal(
-        arc4.String("Proposta 1"),
-        arc4.String("Descripció 1"),
-        options,
-        arc4.UInt64(VALID_START),
-        arc4.UInt64(VALID_END),
-    )
-    id2 = contract.create_proposal(
-        arc4.String("Proposta 2"),
-        arc4.String("Descripció 2"),
-        options,
-        arc4.UInt64(VALID_START),
-        arc4.UInt64(VALID_END),
-    )
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        id1 = contract.create_proposal(
+            org_id,
+            arc4.String("Proposta 1"),
+            arc4.String("Descripció 1"),
+            options,
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
+        id2 = contract.create_proposal(
+            org_id,
+            arc4.String("Proposta 2"),
+            arc4.String("Descripció 2"),
+            options,
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
     assert id1 == arc4.UInt64(1)
     assert id2 == arc4.UInt64(2)
 
 
 def test_create_proposal_stores_proposal_on_chain(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
+    sender, org_id = org_setup
     title = arc4.String("Títol")
     description = arc4.String("Descripció")
 
-    proposal_id = contract.create_proposal(
-        title,
-        description,
-        arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-        arc4.UInt64(VALID_START),
-        arc4.UInt64(VALID_END),
-    )
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        proposal_id = contract.create_proposal(
+            org_id,
+            title,
+            description,
+            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+            arc4.UInt64(VALID_START),
+            arc4.UInt64(VALID_END),
+        )
     proposal = contract.proposals[proposal_id]
 
+    assert proposal.org_id == org_id
     assert proposal.title == title
     assert proposal.description == description
     assert proposal.starting_date == arc4.UInt64(VALID_START)
@@ -88,153 +108,215 @@ def test_create_proposal_stores_proposal_on_chain(
 
 
 def test_create_proposal_stores_creator(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    sender = context.any.account()
-
+    sender, org_id = org_setup
     with context.txn.create_group(active_txn_overrides={"sender": sender}):
         proposal_id = contract.create_proposal(
+            org_id,
             arc4.String("Títol"),
             arc4.String("Descripció"),
             arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
             arc4.UInt64(VALID_START),
             arc4.UInt64(VALID_END),
         )
-
     assert contract.proposals[proposal_id].creator == arc4.Address(sender)
 
 
-def test_create_proposal_starting_too_soon_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+def test_create_proposal_org_not_found_raises_error(
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
+    sender, _ = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="org.not-found"):
+            contract.create_proposal(
+                arc4.UInt64(99),
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
+
+
+def test_create_proposal_unauthorized_raises_error(
+    context: AlgopyTestContext, contract: Demochain, org_setup
+) -> None:
+    _, org_id = org_setup
+    outsider = context.any.account()
+    with context.txn.create_group(active_txn_overrides={"sender": outsider}):
+        with pytest.raises(AssertionError, match="proposal.unauthorized"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
+
+
+def test_create_proposal_starting_too_soon_raises_error(
+    context: AlgopyTestContext, contract: Demochain, org_setup
+) -> None:
+    sender, org_id = org_setup
     too_soon = arc4.UInt64(
         NOW + MIN_VOTING_WINDOW
     )  # només 1 dia d'antelació, cal mínim 3
-    with pytest.raises(AssertionError, match="proposal.starting-too-soon"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            too_soon,
-            arc4.UInt64(NOW + MIN_VOTING_WINDOW * 2),
-        )
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.starting-too-soon"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                too_soon,
+                arc4.UInt64(NOW + MIN_VOTING_WINDOW * 2),
+            )
 
 
 def test_create_proposal_small_voting_window_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
+    sender, org_id = org_setup
     short_end = arc4.UInt64(
         VALID_START + MIN_VOTING_WINDOW - 1
     )  # 1 segon per sota del mínim
-    with pytest.raises(AssertionError, match="proposal.small-voting-window"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            arc4.UInt64(VALID_START),
-            short_end,
-        )
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.small-voting-window"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                short_end,
+            )
 
 
 def test_create_proposal_too_few_options_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.too-few-options"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Única opció")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.too-few-options"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Única opció")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_empty_option_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-options"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Opció A"), arc4.String("")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-options"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Opció A"), arc4.String("")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_blank_option_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-options"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Opció A"), arc4.String("   ")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-options"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Opció A"), arc4.String("   ")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_duplicated_options_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.duplicated-options"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Igual"), arc4.String("Igual")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.duplicated-options"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Igual"), arc4.String("Igual")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_empty_title_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-title"):
-        contract.create_proposal(
-            arc4.String(""),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-title"):
+            contract.create_proposal(
+                org_id,
+                arc4.String(""),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_blank_title_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-title"):
-        contract.create_proposal(
-            arc4.String("   "),
-            arc4.String("Descripció"),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-title"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("   "),
+                arc4.String("Descripció"),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_empty_description_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-description"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String(""),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-description"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String(""),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )
 
 
 def test_create_proposal_blank_description_raises_error(
-    context: AlgopyTestContext, contract: Demochain
+    context: AlgopyTestContext, contract: Demochain, org_setup
 ) -> None:
-    with pytest.raises(AssertionError, match="proposal.empty-description"):
-        contract.create_proposal(
-            arc4.String("Títol"),
-            arc4.String("   "),
-            arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
-            arc4.UInt64(VALID_START),
-            arc4.UInt64(VALID_END),
-        )
+    sender, org_id = org_setup
+    with context.txn.create_group(active_txn_overrides={"sender": sender}):
+        with pytest.raises(AssertionError, match="proposal.empty-description"):
+            contract.create_proposal(
+                org_id,
+                arc4.String("Títol"),
+                arc4.String("   "),
+                arc4.DynamicArray(arc4.String("Sí"), arc4.String("No")),
+                arc4.UInt64(VALID_START),
+                arc4.UInt64(VALID_END),
+            )


### PR DESCRIPTION
…ons + tests

## Descripció del canvi

Creada la funció al _smart contract_ per generar una proposta.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #311 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
