### PR TITLE
chore(network): configurar projecte Hardhat per al contracte Ethereum

### DIFF
--- a/network/ethereum/.env.example
+++ b/network/ethereum/.env.example
@@ -1,0 +1,10 @@
+# URL RPC del node Ethereum per a Sepolia testnet
+# Exemple: https://sepolia.infura.io/v3/<PROJECT_ID>
+ETHEREUM_RPC_URL=
+
+# Clau privada de l'administrador del NotaryContract per al desplegament
+# Exemple: 0xabc123...
+NOTARY_ADMIN_PRIVATE_KEY=
+
+# Adreça del NotaryContract ja desplegat (s'omple després del deploy)
+NOTARY_CONTRACT_ADDRESS=

--- a/network/ethereum/.gitignore
+++ b/network/ethereum/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+artifacts/
+cache/
+coverage/
+coverage.json
+typechain-types/
+.env

--- a/network/ethereum/hardhat.config.js
+++ b/network/ethereum/hardhat.config.js
@@ -1,0 +1,19 @@
+require("@nomicfoundation/hardhat-toolbox");
+require("dotenv").config({ path: "../.env" });
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    hardhat: {},
+    localhost: {
+      url: "http://127.0.0.1:8545",
+    },
+    sepolia: {
+      url: process.env.ETHEREUM_RPC_URL || "",
+      accounts: process.env.NOTARY_ADMIN_PRIVATE_KEY
+        ? [process.env.NOTARY_ADMIN_PRIVATE_KEY]
+        : [],
+    },
+  },
+};

--- a/network/ethereum/package.json
+++ b/network/ethereum/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demochain-ethereum",
+  "version": "1.0.0",
+  "description": "NotaryContract per a l'ancoratge K-de-N dels resultats electorals",
+  "scripts": {
+    "test": "hardhat test",
+    "compile": "hardhat compile",
+    "node": "hardhat node",
+    "deploy:local": "hardhat run scripts/deploy.js --network localhost",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^4.0.0",
+    "hardhat": "^2.22.0"
+  },
+  "dependencies": {
+    "dotenv": "^16.0.0"
+  }
+}


### PR DESCRIPTION
## Descripció del canvi

Configuració inicial del projecte Hardhat a `network/ethereum/`: `package.json`, `hardhat.config.js` (Hardhat local + Sepolia), `.gitignore` i `.env.example` amb totes les variables necessàries.

## Tipus de canvi

- [ ] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [x] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #415

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal