### PR TITLE
feat(network): afegir NotaryContract.sol amb tests i script de desplegament

### DIFF
--- a/network/ethereum/.env.example
+++ b/network/ethereum/.env.example
@@ -1,0 +1,10 @@
+# URL RPC del node Ethereum per a Sepolia testnet
+# Exemple: https://sepolia.infura.io/v3/<PROJECT_ID>
+ETHEREUM_RPC_URL=
+
+# Clau privada de l'administrador del NotaryContract per al desplegament
+# Exemple: 0xabc123...
+NOTARY_ADMIN_PRIVATE_KEY=
+
+# Adreça del NotaryContract ja desplegat (s'omple després del deploy)
+NOTARY_CONTRACT_ADDRESS=

--- a/network/ethereum/.gitignore
+++ b/network/ethereum/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+artifacts/
+cache/
+coverage/
+coverage.json
+typechain-types/
+.env

--- a/network/ethereum/contracts/NotaryContract.sol
+++ b/network/ethereum/contracts/NotaryContract.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title  NotaryContract
+ * @notice Ancoratge K-de-N dels resultats electorals de Demochain.
+ *
+ *         Cada node universitari envia de forma independent el hash SHA-256
+ *         de les paperetes d'una proposta llegides des d'Algorand. Quan K
+ *         nodes envien el mateix hash, el resultat queda ancorat permanentment.
+ *
+ * @dev    La llista blanca i el llindar K es congelen en obrir l'elecció.
+ *         Canvis posteriors de membres no afecten les eleccions en curs.
+ */
+contract NotaryContract {
+
+    address public admin;
+    address[] private _universityList;
+    mapping(address => bool) public whitelist;
+    uint256 public universityCount;
+    uint256 public globalK;
+
+    struct Election {
+        uint256 thresholdK;
+        address[] authorizedNodes;
+        mapping(address => bool) isAuthorized;
+        mapping(address => bytes32) submissions;
+        mapping(bytes32 => uint256) hashCount;
+        bool open;
+        bool anchored;
+    }
+
+    mapping(string => Election) private _elections;
+
+    event UniversityAdded(address indexed university);
+    event UniversityRemoved(address indexed university);
+    event ElectionOpened(string indexed electionId, uint256 thresholdK, uint256 nodeCount);
+    event HashSubmitted(string indexed electionId, bytes32 resultHash, address indexed submitter);
+    event ResultAnchored(string indexed electionId, bytes32 resultHash, uint256 confirmations);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "NotaryContract: not admin");
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    function addUniversity(address uni) external onlyAdmin {
+        require(uni != address(0), "NotaryContract: zero address");
+        require(!whitelist[uni], "NotaryContract: already whitelisted");
+        whitelist[uni] = true;
+        _universityList.push(uni);
+        universityCount++;
+        globalK = _ceilTwoThirds(universityCount);
+        emit UniversityAdded(uni);
+    }
+
+    function removeUniversity(address uni) external onlyAdmin {
+        require(whitelist[uni], "NotaryContract: not whitelisted");
+        whitelist[uni] = false;
+        uint256 len = _universityList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_universityList[i] == uni) {
+                _universityList[i] = _universityList[len - 1];
+                _universityList.pop();
+                break;
+            }
+        }
+        universityCount--;
+        globalK = universityCount > 0 ? _ceilTwoThirds(universityCount) : 0;
+        emit UniversityRemoved(uni);
+    }
+
+    function openElection(string calldata electionId) external onlyAdmin {
+        Election storage e = _elections[electionId];
+        require(!e.open, "NotaryContract: election already open");
+        require(universityCount > 0, "NotaryContract: no universities registered");
+        e.open = true;
+        e.thresholdK = globalK;
+        uint256 len = _universityList.length;
+        for (uint256 i = 0; i < len; i++) {
+            address uni = _universityList[i];
+            e.authorizedNodes.push(uni);
+            e.isAuthorized[uni] = true;
+        }
+        emit ElectionOpened(electionId, e.thresholdK, len);
+    }
+
+    function submitHash(string calldata electionId, bytes32 resultHash) external {
+        Election storage e = _elections[electionId];
+        require(e.open, "NotaryContract: election not open");
+        require(!e.anchored, "NotaryContract: already anchored");
+        require(e.isAuthorized[msg.sender], "NotaryContract: not authorized");
+        require(e.submissions[msg.sender] == bytes32(0), "NotaryContract: already submitted");
+        require(resultHash != bytes32(0), "NotaryContract: zero hash");
+        e.submissions[msg.sender] = resultHash;
+        uint256 count = ++e.hashCount[resultHash];
+        emit HashSubmitted(electionId, resultHash, msg.sender);
+        if (count >= e.thresholdK) {
+            e.anchored = true;
+            emit ResultAnchored(electionId, resultHash, count);
+        }
+    }
+
+    function isElectionAnchored(string calldata electionId) external view returns (bool) {
+        return _elections[electionId].anchored;
+    }
+
+    function getSubmission(string calldata electionId, address submitter)
+        external view returns (bytes32)
+    {
+        return _elections[electionId].submissions[submitter];
+    }
+
+    function universityList() external view returns (address[] memory) {
+        return _universityList;
+    }
+
+    /// @dev ceil(2n/3) = (2n + 2) / 3
+    function _ceilTwoThirds(uint256 n) internal pure returns (uint256) {
+        return (2 * n + 2) / 3;
+    }
+}

--- a/network/ethereum/hardhat.config.js
+++ b/network/ethereum/hardhat.config.js
@@ -1,0 +1,19 @@
+require("@nomicfoundation/hardhat-toolbox");
+require("dotenv").config({ path: "../.env" });
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    hardhat: {},
+    localhost: {
+      url: "http://127.0.0.1:8545",
+    },
+    sepolia: {
+      url: process.env.ETHEREUM_RPC_URL || "",
+      accounts: process.env.NOTARY_ADMIN_PRIVATE_KEY
+        ? [process.env.NOTARY_ADMIN_PRIVATE_KEY]
+        : [],
+    },
+  },
+};

--- a/network/ethereum/package.json
+++ b/network/ethereum/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demochain-ethereum",
+  "version": "1.0.0",
+  "description": "NotaryContract per a l'ancoratge K-de-N dels resultats electorals",
+  "scripts": {
+    "test": "hardhat test",
+    "compile": "hardhat compile",
+    "node": "hardhat node",
+    "deploy:local": "hardhat run scripts/deploy.js --network localhost",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^4.0.0",
+    "hardhat": "^2.22.0"
+  },
+  "dependencies": {
+    "dotenv": "^16.0.0"
+  }
+}

--- a/network/ethereum/scripts/deploy.js
+++ b/network/ethereum/scripts/deploy.js
@@ -1,0 +1,20 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Desplegant NotaryContract amb:", deployer.address);
+
+  const NotaryContract = await ethers.getContractFactory("NotaryContract");
+  const notary = await NotaryContract.deploy();
+  await notary.waitForDeployment();
+
+  const address = await notary.getAddress();
+  console.log("NotaryContract desplegat a:", address);
+  console.log("\nAfegeix al fitxer .env:");
+  console.log("  NOTARY_CONTRACT_ADDRESS=" + address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/network/ethereum/test/NotaryContract.test.js
+++ b/network/ethereum/test/NotaryContract.test.js
@@ -1,0 +1,190 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("NotaryContract", function () {
+  let notary;
+  let admin, uni1, uni2, uni3, uni4, stranger;
+
+  beforeEach(async function () {
+    [admin, uni1, uni2, uni3, uni4, stranger] = await ethers.getSigners();
+    const NotaryContract = await ethers.getContractFactory("NotaryContract");
+    notary = await NotaryContract.deploy();
+  });
+
+  describe("addUniversity", function () {
+    it("afegeix una universitat i emet UniversityAdded", async function () {
+      await expect(notary.addUniversity(uni1.address))
+        .to.emit(notary, "UniversityAdded")
+        .withArgs(uni1.address);
+      expect(await notary.whitelist(uni1.address)).to.be.true;
+      expect(await notary.universityCount()).to.equal(1);
+    });
+
+    it("recalcula K correctament en afegir universitats", async function () {
+      await notary.addUniversity(uni1.address);   // N=1 → K=1
+      expect(await notary.globalK()).to.equal(1);
+      await notary.addUniversity(uni2.address);   // N=2 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.addUniversity(uni3.address);   // N=3 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.addUniversity(uni4.address);   // N=4 → K=3
+      expect(await notary.globalK()).to.equal(3);
+    });
+
+    it("rebutja una adreça zero", async function () {
+      await expect(notary.addUniversity(ethers.ZeroAddress))
+        .to.be.revertedWith("NotaryContract: zero address");
+    });
+
+    it("rebutja una universitat ja registrada", async function () {
+      await notary.addUniversity(uni1.address);
+      await expect(notary.addUniversity(uni1.address))
+        .to.be.revertedWith("NotaryContract: already whitelisted");
+    });
+
+    it("rebutja crides de no-admin", async function () {
+      await expect(notary.connect(uni1).addUniversity(uni2.address))
+        .to.be.revertedWith("NotaryContract: not admin");
+    });
+  });
+
+  describe("removeUniversity", function () {
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);  // N=3, K=2
+    });
+
+    it("elimina una universitat i emet UniversityRemoved", async function () {
+      await expect(notary.removeUniversity(uni3.address))
+        .to.emit(notary, "UniversityRemoved")
+        .withArgs(uni3.address);
+      expect(await notary.whitelist(uni3.address)).to.be.false;
+      expect(await notary.universityCount()).to.equal(2);
+    });
+
+    it("recalcula K correctament en eliminar universitats", async function () {
+      await notary.removeUniversity(uni3.address);  // N=2 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.removeUniversity(uni2.address);  // N=1 → K=1
+      expect(await notary.globalK()).to.equal(1);
+      await notary.removeUniversity(uni1.address);  // N=0 → K=0
+      expect(await notary.globalK()).to.equal(0);
+    });
+
+    it("rebutja eliminar una universitat no registrada", async function () {
+      await expect(notary.removeUniversity(stranger.address))
+        .to.be.revertedWith("NotaryContract: not whitelisted");
+    });
+  });
+
+  describe("openElection", function () {
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);  // N=3, K=2
+    });
+
+    it("obre una elecció i emet ElectionOpened amb la instantània correcta", async function () {
+      await expect(notary.openElection("proposta-1"))
+        .to.emit(notary, "ElectionOpened")
+        .withArgs("proposta-1", 2, 3);
+    });
+
+    it("rebutja obrir la mateixa elecció dues vegades", async function () {
+      await notary.openElection("proposta-1");
+      await expect(notary.openElection("proposta-1"))
+        .to.be.revertedWith("NotaryContract: election already open");
+    });
+
+    it("rebutja obrir una elecció sense universitats registrades", async function () {
+      const NotaryContract = await ethers.getContractFactory("NotaryContract");
+      const buit = await NotaryContract.deploy();
+      await expect(buit.openElection("proposta-1"))
+        .to.be.revertedWith("NotaryContract: no universities registered");
+    });
+
+    it("la instantània de K és independent dels canvis globals posteriors", async function () {
+      await notary.openElection("proposta-1");  // instantània K=2
+      await notary.addUniversity(uni4.address); // globalK ara és 3
+      const HASH = ethers.keccak256(ethers.toUtf8Bytes("resultat"));
+      await notary.connect(uni1).submitHash("proposta-1", HASH);
+      await expect(notary.connect(uni2).submitHash("proposta-1", HASH))
+        .to.emit(notary, "ResultAnchored");  // ancora amb K=2, no K=3
+    });
+  });
+
+  describe("submitHash", function () {
+    const ELECTION = "proposta-1";
+    const HASH_A = ethers.keccak256(ethers.toUtf8Bytes("resultat_a"));
+    const HASH_B = ethers.keccak256(ethers.toUtf8Bytes("resultat_b"));
+
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);
+      await notary.openElection(ELECTION);
+    });
+
+    it("accepta una submissió vàlida i emet HashSubmitted", async function () {
+      await expect(notary.connect(uni1).submitHash(ELECTION, HASH_A))
+        .to.emit(notary, "HashSubmitted")
+        .withArgs(ELECTION, HASH_A, uni1.address);
+    });
+
+    it("registra correctament la submissió", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      expect(await notary.getSubmission(ELECTION, uni1.address)).to.equal(HASH_A);
+    });
+
+    it("rebutja una submissió d'una adreça no autoritzada", async function () {
+      await expect(notary.connect(stranger).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: not authorized");
+    });
+
+    it("rebutja una submissió per a una elecció no oberta", async function () {
+      await expect(notary.connect(uni1).submitHash("desconeguda", HASH_A))
+        .to.be.revertedWith("NotaryContract: election not open");
+    });
+
+    it("rebutja una submissió duplicada del mateix node", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await expect(notary.connect(uni1).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: already submitted");
+    });
+
+    it("rebutja un hash zero", async function () {
+      await expect(notary.connect(uni1).submitHash(ELECTION, ethers.ZeroHash))
+        .to.be.revertedWith("NotaryContract: zero hash");
+    });
+
+    it("emet ResultAnchored quan K nodes envien el mateix hash", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await expect(notary.connect(uni2).submitHash(ELECTION, HASH_A))
+        .to.emit(notary, "ResultAnchored")
+        .withArgs(ELECTION, HASH_A, 2);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.true;
+    });
+
+    it("no ancora si els hashes no coincideixen", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await notary.connect(uni2).submitHash(ELECTION, HASH_B);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.false;
+    });
+
+    it("rebutja submissions després que l'elecció ja està ancorada", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await notary.connect(uni2).submitHash(ELECTION, HASH_A);  // ancora
+      await expect(notary.connect(uni3).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: already anchored");
+    });
+
+    it("permet eleccions múltiples de forma independent", async function () {
+      await notary.openElection("proposta-2");
+      await notary.connect(uni1).submitHash(ELECTION,     HASH_A);
+      await notary.connect(uni1).submitHash("proposta-2", HASH_B);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.false;
+      expect(await notary.isElectionAnchored("proposta-2")).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Descripció del canvi

Contracte Solidity `NotaryContract` portat i adaptat a `network/ethereum/contracts/`. Implementa el consens K-de-N per a l'ancoratge distribuït dels resultats electorals. Inclou 22 tests Hardhat i el script de desplegament.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [x] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #416

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal