### PR TITLE
feat(network): implementar Hasher per a paperetes de preferència Schulze

### DIFF
--- a/network/anchoring/algorand_reader.py
+++ b/network/anchoring/algorand_reader.py
@@ -1,0 +1,202 @@
+"""Llegeix l'estat d'una elecció (proposta + paperetes) des del contracte Demochain.
+
+Estructura de BoxMaps rellevant (vegeu contract.py):
+  pr_<UInt64>                → struct Proposal (title, description, options, org_id, creator, start, end)
+  eb_<BallotId>              → DynamicArray[UInt8]  (ordre de preferència del votant)
+    on BallotId = (arc4.Address[32B] + arc4.UInt64[8B]) = 40 bytes
+
+Codificació ARC-4 del struct Proposal (camps dinàmics primer al head):
+  Head (62 bytes):
+    [0:2]  offset→title        (uint16 BE, absolut des de l'inici)
+    [2:4]  offset→description  (uint16 BE)
+    [4:6]  offset→options      (uint16 BE)
+    [6:14] org_id              (uint64 BE)
+    [14:46] creator            (32 bytes)
+    [46:54] starting_date      (uint64 BE)
+    [54:62] ending_date        (uint64 BE)
+  Tail: dades dels camps dinàmics en ordre (title, description, options)
+"""
+
+import base64
+import logging
+import struct
+from typing import Optional
+
+from algosdk.v2client.algod import AlgodClient
+
+from .models import Ballot, ElectionState
+
+logger = logging.getLogger(__name__)
+
+BOX_PREFIX_PROPOSAL = b"pr_"
+BOX_PREFIX_BALLOT = b"eb_"
+
+# Mida del head d'un struct Proposal (3 offsets × 2B + org_id 8B + creator 32B + 2 dates × 8B)
+_PROPOSAL_HEAD_SIZE = 3 * 2 + 8 + 32 + 8 + 8  # = 62
+
+
+def _read_arc4_string(data: bytes, offset: int) -> tuple[str, int]:
+    """Descodifica un arc4.String des de `data` a la posició `offset`.
+
+    Returns:
+        (valor, offset_final) — offset just després de la cadena.
+    """
+    length = struct.unpack_from(">H", data, offset)[0]
+    text = data[offset + 2 : offset + 2 + length].decode("utf-8")
+    return text, offset + 2 + length
+
+
+def _read_arc4_string_array(data: bytes, offset: int) -> list[str]:
+    """Descodifica un arc4.DynamicArray[String] des de `data` a `offset`."""
+    count = struct.unpack_from(">H", data, offset)[0]
+    if count == 0:
+        return []
+    base = offset + 2  # byte just després del count; els offsets són relatius a aquí
+    offsets = [struct.unpack_from(">H", data, base + i * 2)[0] for i in range(count)]
+    result = []
+    for rel_off in offsets:
+        abs_off = base + rel_off
+        s, _ = _read_arc4_string(data, abs_off)
+        result.append(s)
+    return result
+
+
+def _decode_proposal(raw: bytes) -> tuple[str, list[str]]:
+    """Extreu el títol i les opcions del bytes crus d'un struct Proposal.
+
+    Returns:
+        (title, options)
+
+    Raises:
+        ValueError: Si les dades són insuficients o mal formades.
+    """
+    if len(raw) < _PROPOSAL_HEAD_SIZE:
+        raise ValueError(f"Proposal massa curta: {len(raw)} bytes")
+
+    offset_title = struct.unpack_from(">H", raw, 0)[0]
+    # offset_description a bytes [2:4] — no el necessitem
+    offset_options = struct.unpack_from(">H", raw, 4)[0]
+
+    title, _ = _read_arc4_string(raw, offset_title)
+    options = _read_arc4_string_array(raw, offset_options)
+    return title, options
+
+
+def _decode_ballot_preference(raw: bytes) -> list[int]:
+    """Descodifica un arc4.DynamicArray[UInt8] (ordre de preferència)."""
+    if len(raw) < 2:
+        return []
+    count = struct.unpack_from(">H", raw, 0)[0]
+    return list(raw[2 : 2 + count])
+
+
+def _ballot_box_key(proposal_id: int, voter_address_bytes: bytes) -> bytes:
+    """Construeix la clau de box per a BallotId(sender, proposal_id).
+
+    ARC-4 Struct encoding (tots dos camps estàtics):
+      voter_address_bytes (32B) + proposal_id uint64 BE (8B)
+    """
+    return BOX_PREFIX_BALLOT + voter_address_bytes + struct.pack(">Q", proposal_id)
+
+
+def _proposal_box_key(proposal_id: int) -> bytes:
+    return BOX_PREFIX_PROPOSAL + struct.pack(">Q", proposal_id)
+
+
+class AlgorandElectionReader:
+    """Llegeix propostes i paperetes des del contracte Demochain via algod."""
+
+    def __init__(self, algod_client: AlgodClient, app_id: int):
+        self.algod = algod_client
+        self.app_id = app_id
+
+    def _box_value(self, name: bytes) -> Optional[bytes]:
+        try:
+            result = self.algod.application_box_by_name(self.app_id, name)
+            return base64.b64decode(result["value"])
+        except Exception as exc:
+            logger.debug("Box no trobada %r: %s", name, exc)
+            return None
+
+    def _list_boxes(self) -> list[bytes]:
+        """Retorna els noms (bytes) de totes les boxes de l'aplicació."""
+        try:
+            resp = self.algod.application_boxes(self.app_id)
+            return [base64.b64decode(b["name"]) for b in resp.get("boxes", [])]
+        except Exception as exc:
+            logger.error("Error llistant boxes de l'app %d: %s", self.app_id, exc)
+            return []
+
+    def read_election_state(self, proposal_id: int) -> Optional[ElectionState]:
+        """Llegeix l'estat complet d'una proposta: títol, opcions i totes les paperetes.
+
+        Args:
+            proposal_id: ID numèric de la proposta (clau al BoxMap pr_).
+
+        Returns:
+            ElectionState amb les paperetes registrades, o None si la proposta
+            no existeix.
+        """
+        prop_raw = self._box_value(_proposal_box_key(proposal_id))
+        if prop_raw is None:
+            logger.warning("Proposta %d no trobada", proposal_id)
+            return None
+
+        try:
+            title, options = _decode_proposal(prop_raw)
+        except ValueError as exc:
+            logger.error("Error descodificant proposta %d: %s", proposal_id, exc)
+            return None
+
+        # Escanejar totes les boxes per trobar les paperetes d'aquesta proposta.
+        # La clau d'una papereta és: b"eb_" + 32B(voter) + 8B(proposal_id).
+        # Filtrem les que acaben amb struct.pack(">Q", proposal_id).
+        pid_suffix = struct.pack(">Q", proposal_id)
+        ballot_prefix = BOX_PREFIX_BALLOT
+        ballot_prefix_len = len(ballot_prefix)
+        address_size = 32
+
+        ballots: list[Ballot] = []
+        for box_name in self._list_boxes():
+            if not box_name.startswith(ballot_prefix):
+                continue
+            payload = box_name[ballot_prefix_len:]  # 40 bytes: 32B addr + 8B pid
+            if len(payload) != address_size + 8:
+                continue
+            if payload[address_size:] != pid_suffix:
+                continue
+
+            voter_bytes = payload[:address_size]
+            ballot_raw = self._box_value(box_name)
+            if ballot_raw is None:
+                continue
+
+            preference = _decode_ballot_preference(ballot_raw)
+            voter_addr = _bytes_to_algorand_address(voter_bytes)
+            ballots.append(Ballot(voter=voter_addr, preference=preference))
+
+        # Ordenar per adreça per garantir ordre determinista.
+        ballots.sort(key=lambda b: b.voter)
+
+        try:
+            status = self.algod.status()
+            block_round = status.get("last-round", 0)
+        except Exception:
+            block_round = 0
+
+        return ElectionState(
+            proposal_id=proposal_id,
+            title=title,
+            options=options,
+            ballots=ballots,
+            block_round=block_round,
+        )
+
+
+def _bytes_to_algorand_address(raw: bytes) -> str:
+    """Converteix 32 bytes de clau pública a adreça Algorand (base32 + checksum)."""
+    import base64 as b64
+    import hashlib
+
+    checksum = hashlib.new("sha512_256", raw).digest()[-4:]
+    return b64.b32encode(raw + checksum).decode("utf-8").rstrip("=")

--- a/network/anchoring/hasher.py
+++ b/network/anchoring/hasher.py
@@ -1,0 +1,44 @@
+"""Càlcul del hash SHA-256 determinista de l'estat d'una elecció Demochain.
+
+A diferència del sistema original (que hashejava comptadors de vots per candidat),
+aquest mòdul hasheja les paperetes de preferència completes (mètode Schulze).
+
+Format canònic JSON (claus ordenades, sense espais):
+  {
+    "ballots": [
+      {"preference": [2, 0, 1], "voter": "ADDR_A"},
+      {"preference": [0, 2, 1], "voter": "ADDR_B"}
+    ],
+    "options": ["Opció A", "Opció B", "Opció C"],
+    "proposal_id": 1,
+    "title": "Rector 2026"
+  }
+
+Les paperetes estan ordenades per `voter` (ordre lexicogràfic) per garantir
+que tots els nodes produeixin exactament el mateix JSON per al mateix estat.
+"""
+
+import hashlib
+import json
+
+from .models import ElectionState
+
+
+def compute_election_hash(state: ElectionState) -> bytes:
+    """Retorna el SHA-256 (32 bytes) de l'estat de l'elecció en forma canònica."""
+    canonical = {
+        "ballots": [
+            {"preference": b.preference, "voter": b.voter}
+            for b in sorted(state.ballots, key=lambda x: x.voter)
+        ],
+        "options": state.options,
+        "proposal_id": state.proposal_id,
+        "title": state.title,
+    }
+    canonical_json = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical_json.encode("utf-8")).digest()
+
+
+def compute_election_hash_hex(state: ElectionState) -> str:
+    """Retorna el SHA-256 en format hexadecimal amb prefix 0x (compatible bytes32 Solidity)."""
+    return "0x" + compute_election_hash(state).hex()

--- a/network/anchoring/models.py
+++ b/network/anchoring/models.py
@@ -11,6 +11,7 @@ class Ballot:
     Exemple amb 3 opcions: preference=[2, 0, 1] significa que el votant
     prefereix l'opció 2 en primer lloc, l'opció 0 en segon i l'opció 1 en tercer.
     """
+
     voter: str
     preference: list[int]
 
@@ -30,6 +31,7 @@ class ElectionState:
         ballots:     Paperetes de tots els votants que han votat.
         block_round: Round d'Algorand en el moment de la lectura (per a auditoria).
     """
+
     proposal_id: int
     title: str
     options: list[str]

--- a/network/anchoring/models.py
+++ b/network/anchoring/models.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Ballot:
+    """Papereta de preferència d'un votant per a una proposta Demochain.
+
+    El contracte Demochain emmagatzema la papereta com a DynamicArray[UInt8]
+    on cada valor és l'índex (0-indexed) de l'opció en la posició de preferència.
+
+    Exemple amb 3 opcions: preference=[2, 0, 1] significa que el votant
+    prefereix l'opció 2 en primer lloc, l'opció 0 en segon i l'opció 1 en tercer.
+    """
+    voter: str
+    preference: list[int]
+
+
+@dataclass
+class ElectionState:
+    """Estat complet d'una elecció llegit des del contracte Demochain (Algorand).
+
+    Representa les paperetes d'una proposta aprovada en el moment de l'ancoratge.
+    A diferència del sistema original (que emmagatzemava comptadors per candidat),
+    Demochain emmagatzema les paperetes de preferència completes (mètode Schulze).
+
+    Atributs:
+        proposal_id: Identificador numèric de la proposta (clau del BoxMap pr_).
+        title:       Títol de la proposta llegit del struct Proposal.
+        options:     Llista d'opcions en l'ordre original del contracte.
+        ballots:     Paperetes de tots els votants que han votat.
+        block_round: Round d'Algorand en el moment de la lectura (per a auditoria).
+    """
+    proposal_id: int
+    title: str
+    options: list[str]
+    ballots: list[Ballot] = field(default_factory=list)
+    block_round: int = 0
+
+    @property
+    def election_id(self) -> str:
+        """Identificador de cadena usat com a electionId al NotaryContract."""
+        return f"proposta-{self.proposal_id}"

--- a/network/anchoring/pyproject.toml
+++ b/network/anchoring/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "demochain-anchoring"
+version = "0.1.0"
+description = "Servei d'ancoratge K-de-N dels resultats electorals de Demochain a Ethereum"
+authors = []
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.12"
+algosdk = "^2.7.0"
+web3 = "^7.0.0"
+python-dotenv = "^1.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/network/ethereum/.env.example
+++ b/network/ethereum/.env.example
@@ -1,0 +1,10 @@
+# URL RPC del node Ethereum per a Sepolia testnet
+# Exemple: https://sepolia.infura.io/v3/<PROJECT_ID>
+ETHEREUM_RPC_URL=
+
+# Clau privada de l'administrador del NotaryContract per al desplegament
+# Exemple: 0xabc123...
+NOTARY_ADMIN_PRIVATE_KEY=
+
+# Adreça del NotaryContract ja desplegat (s'omple després del deploy)
+NOTARY_CONTRACT_ADDRESS=

--- a/network/ethereum/.gitignore
+++ b/network/ethereum/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+artifacts/
+cache/
+coverage/
+coverage.json
+typechain-types/
+.env

--- a/network/ethereum/contracts/NotaryContract.sol
+++ b/network/ethereum/contracts/NotaryContract.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title  NotaryContract
+ * @notice Ancoratge K-de-N dels resultats electorals de Demochain.
+ *
+ *         Cada node universitari envia de forma independent el hash SHA-256
+ *         de les paperetes d'una proposta llegides des d'Algorand. Quan K
+ *         nodes envien el mateix hash, el resultat queda ancorat permanentment.
+ *
+ * @dev    La llista blanca i el llindar K es congelen en obrir l'elecció.
+ *         Canvis posteriors de membres no afecten les eleccions en curs.
+ */
+contract NotaryContract {
+
+    address public admin;
+    address[] private _universityList;
+    mapping(address => bool) public whitelist;
+    uint256 public universityCount;
+    uint256 public globalK;
+
+    struct Election {
+        uint256 thresholdK;
+        address[] authorizedNodes;
+        mapping(address => bool) isAuthorized;
+        mapping(address => bytes32) submissions;
+        mapping(bytes32 => uint256) hashCount;
+        bool open;
+        bool anchored;
+    }
+
+    mapping(string => Election) private _elections;
+
+    event UniversityAdded(address indexed university);
+    event UniversityRemoved(address indexed university);
+    event ElectionOpened(string indexed electionId, uint256 thresholdK, uint256 nodeCount);
+    event HashSubmitted(string indexed electionId, bytes32 resultHash, address indexed submitter);
+    event ResultAnchored(string indexed electionId, bytes32 resultHash, uint256 confirmations);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "NotaryContract: not admin");
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    function addUniversity(address uni) external onlyAdmin {
+        require(uni != address(0), "NotaryContract: zero address");
+        require(!whitelist[uni], "NotaryContract: already whitelisted");
+        whitelist[uni] = true;
+        _universityList.push(uni);
+        universityCount++;
+        globalK = _ceilTwoThirds(universityCount);
+        emit UniversityAdded(uni);
+    }
+
+    function removeUniversity(address uni) external onlyAdmin {
+        require(whitelist[uni], "NotaryContract: not whitelisted");
+        whitelist[uni] = false;
+        uint256 len = _universityList.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (_universityList[i] == uni) {
+                _universityList[i] = _universityList[len - 1];
+                _universityList.pop();
+                break;
+            }
+        }
+        universityCount--;
+        globalK = universityCount > 0 ? _ceilTwoThirds(universityCount) : 0;
+        emit UniversityRemoved(uni);
+    }
+
+    function openElection(string calldata electionId) external onlyAdmin {
+        Election storage e = _elections[electionId];
+        require(!e.open, "NotaryContract: election already open");
+        require(universityCount > 0, "NotaryContract: no universities registered");
+        e.open = true;
+        e.thresholdK = globalK;
+        uint256 len = _universityList.length;
+        for (uint256 i = 0; i < len; i++) {
+            address uni = _universityList[i];
+            e.authorizedNodes.push(uni);
+            e.isAuthorized[uni] = true;
+        }
+        emit ElectionOpened(electionId, e.thresholdK, len);
+    }
+
+    function submitHash(string calldata electionId, bytes32 resultHash) external {
+        Election storage e = _elections[electionId];
+        require(e.open, "NotaryContract: election not open");
+        require(!e.anchored, "NotaryContract: already anchored");
+        require(e.isAuthorized[msg.sender], "NotaryContract: not authorized");
+        require(e.submissions[msg.sender] == bytes32(0), "NotaryContract: already submitted");
+        require(resultHash != bytes32(0), "NotaryContract: zero hash");
+        e.submissions[msg.sender] = resultHash;
+        uint256 count = ++e.hashCount[resultHash];
+        emit HashSubmitted(electionId, resultHash, msg.sender);
+        if (count >= e.thresholdK) {
+            e.anchored = true;
+            emit ResultAnchored(electionId, resultHash, count);
+        }
+    }
+
+    function isElectionAnchored(string calldata electionId) external view returns (bool) {
+        return _elections[electionId].anchored;
+    }
+
+    function getSubmission(string calldata electionId, address submitter)
+        external view returns (bytes32)
+    {
+        return _elections[electionId].submissions[submitter];
+    }
+
+    function universityList() external view returns (address[] memory) {
+        return _universityList;
+    }
+
+    /// @dev ceil(2n/3) = (2n + 2) / 3
+    function _ceilTwoThirds(uint256 n) internal pure returns (uint256) {
+        return (2 * n + 2) / 3;
+    }
+}

--- a/network/ethereum/hardhat.config.js
+++ b/network/ethereum/hardhat.config.js
@@ -1,0 +1,19 @@
+require("@nomicfoundation/hardhat-toolbox");
+require("dotenv").config({ path: "../.env" });
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    hardhat: {},
+    localhost: {
+      url: "http://127.0.0.1:8545",
+    },
+    sepolia: {
+      url: process.env.ETHEREUM_RPC_URL || "",
+      accounts: process.env.NOTARY_ADMIN_PRIVATE_KEY
+        ? [process.env.NOTARY_ADMIN_PRIVATE_KEY]
+        : [],
+    },
+  },
+};

--- a/network/ethereum/package.json
+++ b/network/ethereum/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demochain-ethereum",
+  "version": "1.0.0",
+  "description": "NotaryContract per a l'ancoratge K-de-N dels resultats electorals",
+  "scripts": {
+    "test": "hardhat test",
+    "compile": "hardhat compile",
+    "node": "hardhat node",
+    "deploy:local": "hardhat run scripts/deploy.js --network localhost",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^4.0.0",
+    "hardhat": "^2.22.0"
+  },
+  "dependencies": {
+    "dotenv": "^16.0.0"
+  }
+}

--- a/network/ethereum/scripts/deploy.js
+++ b/network/ethereum/scripts/deploy.js
@@ -1,0 +1,20 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Desplegant NotaryContract amb:", deployer.address);
+
+  const NotaryContract = await ethers.getContractFactory("NotaryContract");
+  const notary = await NotaryContract.deploy();
+  await notary.waitForDeployment();
+
+  const address = await notary.getAddress();
+  console.log("NotaryContract desplegat a:", address);
+  console.log("\nAfegeix al fitxer .env:");
+  console.log("  NOTARY_CONTRACT_ADDRESS=" + address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/network/ethereum/test/NotaryContract.test.js
+++ b/network/ethereum/test/NotaryContract.test.js
@@ -1,0 +1,190 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("NotaryContract", function () {
+  let notary;
+  let admin, uni1, uni2, uni3, uni4, stranger;
+
+  beforeEach(async function () {
+    [admin, uni1, uni2, uni3, uni4, stranger] = await ethers.getSigners();
+    const NotaryContract = await ethers.getContractFactory("NotaryContract");
+    notary = await NotaryContract.deploy();
+  });
+
+  describe("addUniversity", function () {
+    it("afegeix una universitat i emet UniversityAdded", async function () {
+      await expect(notary.addUniversity(uni1.address))
+        .to.emit(notary, "UniversityAdded")
+        .withArgs(uni1.address);
+      expect(await notary.whitelist(uni1.address)).to.be.true;
+      expect(await notary.universityCount()).to.equal(1);
+    });
+
+    it("recalcula K correctament en afegir universitats", async function () {
+      await notary.addUniversity(uni1.address);   // N=1 → K=1
+      expect(await notary.globalK()).to.equal(1);
+      await notary.addUniversity(uni2.address);   // N=2 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.addUniversity(uni3.address);   // N=3 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.addUniversity(uni4.address);   // N=4 → K=3
+      expect(await notary.globalK()).to.equal(3);
+    });
+
+    it("rebutja una adreça zero", async function () {
+      await expect(notary.addUniversity(ethers.ZeroAddress))
+        .to.be.revertedWith("NotaryContract: zero address");
+    });
+
+    it("rebutja una universitat ja registrada", async function () {
+      await notary.addUniversity(uni1.address);
+      await expect(notary.addUniversity(uni1.address))
+        .to.be.revertedWith("NotaryContract: already whitelisted");
+    });
+
+    it("rebutja crides de no-admin", async function () {
+      await expect(notary.connect(uni1).addUniversity(uni2.address))
+        .to.be.revertedWith("NotaryContract: not admin");
+    });
+  });
+
+  describe("removeUniversity", function () {
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);  // N=3, K=2
+    });
+
+    it("elimina una universitat i emet UniversityRemoved", async function () {
+      await expect(notary.removeUniversity(uni3.address))
+        .to.emit(notary, "UniversityRemoved")
+        .withArgs(uni3.address);
+      expect(await notary.whitelist(uni3.address)).to.be.false;
+      expect(await notary.universityCount()).to.equal(2);
+    });
+
+    it("recalcula K correctament en eliminar universitats", async function () {
+      await notary.removeUniversity(uni3.address);  // N=2 → K=2
+      expect(await notary.globalK()).to.equal(2);
+      await notary.removeUniversity(uni2.address);  // N=1 → K=1
+      expect(await notary.globalK()).to.equal(1);
+      await notary.removeUniversity(uni1.address);  // N=0 → K=0
+      expect(await notary.globalK()).to.equal(0);
+    });
+
+    it("rebutja eliminar una universitat no registrada", async function () {
+      await expect(notary.removeUniversity(stranger.address))
+        .to.be.revertedWith("NotaryContract: not whitelisted");
+    });
+  });
+
+  describe("openElection", function () {
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);  // N=3, K=2
+    });
+
+    it("obre una elecció i emet ElectionOpened amb la instantània correcta", async function () {
+      await expect(notary.openElection("proposta-1"))
+        .to.emit(notary, "ElectionOpened")
+        .withArgs("proposta-1", 2, 3);
+    });
+
+    it("rebutja obrir la mateixa elecció dues vegades", async function () {
+      await notary.openElection("proposta-1");
+      await expect(notary.openElection("proposta-1"))
+        .to.be.revertedWith("NotaryContract: election already open");
+    });
+
+    it("rebutja obrir una elecció sense universitats registrades", async function () {
+      const NotaryContract = await ethers.getContractFactory("NotaryContract");
+      const buit = await NotaryContract.deploy();
+      await expect(buit.openElection("proposta-1"))
+        .to.be.revertedWith("NotaryContract: no universities registered");
+    });
+
+    it("la instantània de K és independent dels canvis globals posteriors", async function () {
+      await notary.openElection("proposta-1");  // instantània K=2
+      await notary.addUniversity(uni4.address); // globalK ara és 3
+      const HASH = ethers.keccak256(ethers.toUtf8Bytes("resultat"));
+      await notary.connect(uni1).submitHash("proposta-1", HASH);
+      await expect(notary.connect(uni2).submitHash("proposta-1", HASH))
+        .to.emit(notary, "ResultAnchored");  // ancora amb K=2, no K=3
+    });
+  });
+
+  describe("submitHash", function () {
+    const ELECTION = "proposta-1";
+    const HASH_A = ethers.keccak256(ethers.toUtf8Bytes("resultat_a"));
+    const HASH_B = ethers.keccak256(ethers.toUtf8Bytes("resultat_b"));
+
+    beforeEach(async function () {
+      await notary.addUniversity(uni1.address);
+      await notary.addUniversity(uni2.address);
+      await notary.addUniversity(uni3.address);
+      await notary.openElection(ELECTION);
+    });
+
+    it("accepta una submissió vàlida i emet HashSubmitted", async function () {
+      await expect(notary.connect(uni1).submitHash(ELECTION, HASH_A))
+        .to.emit(notary, "HashSubmitted")
+        .withArgs(ELECTION, HASH_A, uni1.address);
+    });
+
+    it("registra correctament la submissió", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      expect(await notary.getSubmission(ELECTION, uni1.address)).to.equal(HASH_A);
+    });
+
+    it("rebutja una submissió d'una adreça no autoritzada", async function () {
+      await expect(notary.connect(stranger).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: not authorized");
+    });
+
+    it("rebutja una submissió per a una elecció no oberta", async function () {
+      await expect(notary.connect(uni1).submitHash("desconeguda", HASH_A))
+        .to.be.revertedWith("NotaryContract: election not open");
+    });
+
+    it("rebutja una submissió duplicada del mateix node", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await expect(notary.connect(uni1).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: already submitted");
+    });
+
+    it("rebutja un hash zero", async function () {
+      await expect(notary.connect(uni1).submitHash(ELECTION, ethers.ZeroHash))
+        .to.be.revertedWith("NotaryContract: zero hash");
+    });
+
+    it("emet ResultAnchored quan K nodes envien el mateix hash", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await expect(notary.connect(uni2).submitHash(ELECTION, HASH_A))
+        .to.emit(notary, "ResultAnchored")
+        .withArgs(ELECTION, HASH_A, 2);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.true;
+    });
+
+    it("no ancora si els hashes no coincideixen", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await notary.connect(uni2).submitHash(ELECTION, HASH_B);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.false;
+    });
+
+    it("rebutja submissions després que l'elecció ja està ancorada", async function () {
+      await notary.connect(uni1).submitHash(ELECTION, HASH_A);
+      await notary.connect(uni2).submitHash(ELECTION, HASH_A);  // ancora
+      await expect(notary.connect(uni3).submitHash(ELECTION, HASH_A))
+        .to.be.revertedWith("NotaryContract: already anchored");
+    });
+
+    it("permet eleccions múltiples de forma independent", async function () {
+      await notary.openElection("proposta-2");
+      await notary.connect(uni1).submitHash(ELECTION,     HASH_A);
+      await notary.connect(uni1).submitHash("proposta-2", HASH_B);
+      expect(await notary.isElectionAnchored(ELECTION)).to.be.false;
+      expect(await notary.isElectionAnchored("proposta-2")).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Descripció del canvi

`Hasher` adaptat per generar el hash SHA-256 determinista de les paperetes Schulze. El JSON canònic inclou totes les paperetes (ordenades per adreça de votant), les opcions i l'ID de la proposta. Qualsevol canvi en una sola papereta produeix un hash diferent.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #419

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal