### PR TITLE
feat(client): landing page amb toggle de tema i canvi d'idioma

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
-    <title>Demochain — Every voice, ranked.</title>
+    <title>Demochain - Every voice, ranked.</title>
     <script>
       (() => {
         const saved = localStorage.getItem('theme');

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,22 @@
+import { Outlet } from 'react-router-dom';
+import { LazyMotion, MotionConfig, domAnimation, useReducedMotion } from 'framer-motion';
+import { Header } from './components/layout/Header';
+import { Footer } from './components/layout/Footer';
+
+export default function App() {
+  const reduced = useReducedMotion();
+
+  return (
+    <LazyMotion features={domAnimation} strict>
+      <MotionConfig reducedMotion={reduced ? 'always' : 'user'}>
+        <div className="flex min-h-full flex-col">
+          <Header />
+          <main className="flex-1">
+            <Outlet />
+          </main>
+          <Footer />
+        </div>
+      </MotionConfig>
+    </LazyMotion>
+  );
+}

--- a/client/src/components/LanguageSwitcher.tsx
+++ b/client/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next';
+import { Globe } from 'lucide-react';
+import { useState } from 'react';
+
+const LANGS = [
+  { code: 'en', label: 'EN' },
+  { code: 'es', label: 'ES' },
+  { code: 'ca', label: 'CA' },
+] as const;
+
+export function LanguageSwitcher() {
+  const { i18n, t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const current = i18n.resolvedLanguage?.slice(0, 2) ?? 'en';
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={t('language.label')}
+        className="inline-flex h-10 items-center gap-2 rounded-full border border-border bg-surface px-3 text-sm font-medium text-fg transition hover:border-primary hover:text-primary"
+      >
+        <Globe size={16} />
+        <span className="uppercase">{current}</span>
+      </button>
+      {open && (
+        <>
+          <button
+            type="button"
+            aria-label="Close language menu"
+            className="fixed inset-0 z-30"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute right-0 top-12 z-40 min-w-[140px] overflow-hidden rounded-xl border border-border bg-elevated shadow-lg">
+            {LANGS.map((l) => (
+              <button
+                key={l.code}
+                type="button"
+                onClick={() => {
+                  i18n.changeLanguage(l.code);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center justify-between px-4 py-2 text-sm transition hover:bg-surface ${
+                  current === l.code ? 'text-primary' : 'text-fg'
+                }`}
+              >
+                <span>{t(`language.${l.code}`)}</span>
+                <span className="text-xs font-semibold uppercase text-muted">{l.label}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../theme/ThemeProvider';
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={t('theme.toggle')}
+      className="inline-flex size-10 items-center justify-center rounded-full border border-border bg-surface text-fg transition hover:border-primary hover:text-primary"
+    >
+      {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/client/src/components/landing/BallotBoxHero.tsx
+++ b/client/src/components/landing/BallotBoxHero.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useRef, useState, type PointerEvent } from 'react';
+import { m, useMotionValue, useSpring, useTransform, useReducedMotion } from 'framer-motion';
+import { HeroBackdrop, HeroCopy } from './HeroCopy';
+
+const VB = { w: 600, h: 460 };
+const F = { x1: 180, y1: 200, x2: 420, y2: 360 };
+const DV = { x: 44, y: -56 };
+
+const C = {
+  fTL: { x: F.x1, y: F.y1 },
+  fTR: { x: F.x2, y: F.y1 },
+  fBL: { x: F.x1, y: F.y2 },
+  fBR: { x: F.x2, y: F.y2 },
+  bTL: { x: F.x1 + DV.x, y: F.y1 + DV.y },
+  bTR: { x: F.x2 + DV.x, y: F.y1 + DV.y },
+  bBL: { x: F.x1 + DV.x, y: F.y2 + DV.y },
+  bBR: { x: F.x2 + DV.x, y: F.y2 + DV.y },
+};
+
+const LID_OVER = 14;
+const SLOT = { x: (F.x1 + F.x2) / 2 + DV.x / 2, y: F.y1 + DV.y / 2 };
+const TOP_MATRIX = `matrix(1 0 ${DV.x / (F.y2 - F.y1)} ${DV.y / (F.y2 - F.y1)} ${F.x1} ${F.y1})`;
+
+interface Flying {
+  id: number;
+  startX: number;
+  startY: number;
+  startRot: number;
+  hue: number;
+}
+
+function BallotDefs() {
+  return (
+    <defs>
+      <linearGradient id="bb-glass-front" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="rgb(var(--primary))" stopOpacity="0.55" />
+        <stop offset="55%" stopColor="rgb(var(--primary))" stopOpacity="0.3" />
+        <stop offset="100%" stopColor="rgb(var(--accent))" stopOpacity="0.45" />
+      </linearGradient>
+      <linearGradient id="bb-glass-side" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stopColor="rgb(var(--primary))" stopOpacity="0.65" />
+        <stop offset="100%" stopColor="rgb(var(--primary))" stopOpacity="0.18" />
+      </linearGradient>
+      <linearGradient id="bb-lid" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="rgb(var(--primary))" />
+        <stop offset="55%" stopColor="rgb(var(--accent))" />
+        <stop offset="100%" stopColor="rgb(var(--primary))" />
+      </linearGradient>
+      <linearGradient id="bb-slot" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stopColor="#030315" />
+        <stop offset="50%" stopColor="#0a0a24" />
+        <stop offset="100%" stopColor="#1a1a40" />
+      </linearGradient>
+      <radialGradient id="bb-halo" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stopColor="rgb(var(--primary))" stopOpacity="0.38" />
+        <stop offset="100%" stopColor="rgb(var(--primary))" stopOpacity="0" />
+      </radialGradient>
+      <filter id="bb-shadow" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur stdDeviation="8" />
+      </filter>
+    </defs>
+  );
+}
+
+function BallotBoxGeometry() {
+  return (
+    <>
+      <circle cx={VB.w / 2} cy={260} r={230} fill="url(#bb-halo)" />
+
+      <ellipse
+        cx={VB.w / 2 + 8}
+        cy={398}
+        rx={200}
+        ry={16}
+        fill="rgb(0 0 0 / 0.5)"
+        filter="url(#bb-shadow)"
+      />
+
+      <polygon
+        points={`${C.fTR.x},${C.fTR.y} ${C.bTR.x},${C.bTR.y} ${C.bBR.x},${C.bBR.y} ${C.fBR.x},${C.fBR.y}`}
+        fill="url(#bb-glass-side)"
+        stroke="rgb(var(--primary) / 0.7)"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+
+      <rect
+        x={F.x1}
+        y={F.y1}
+        width={F.x2 - F.x1}
+        height={F.y2 - F.y1}
+        rx="6"
+        fill="url(#bb-glass-front)"
+        stroke="rgb(var(--primary) / 0.6)"
+        strokeWidth="1.5"
+      />
+      <rect
+        x={F.x1 + 12}
+        y={F.y1 + 10}
+        width="3"
+        height={F.y2 - F.y1 - 20}
+        rx="1.5"
+        fill="rgb(255 255 255 / 0.35)"
+      />
+      <rect
+        x={F.x2 - 14}
+        y={F.y1 + 14}
+        width="1.5"
+        height={F.y2 - F.y1 - 30}
+        rx="1"
+        fill="rgb(255 255 255 / 0.18)"
+      />
+
+      <line x1={C.fTR.x} y1={C.fTR.y} x2={C.bTR.x} y2={C.bTR.y} stroke="rgb(var(--primary) / 0.55)" strokeWidth="1.1" />
+      <line x1={C.fBR.x} y1={C.fBR.y} x2={C.bBR.x} y2={C.bBR.y} stroke="rgb(var(--primary) / 0.38)" strokeWidth="1" />
+
+      <line x1={C.bTL.x} y1={C.bTL.y} x2={C.bBL.x} y2={C.bBL.y} stroke="rgb(var(--primary) / 0.45)" strokeWidth="1" strokeDasharray="4 3" />
+      <line x1={C.fBL.x} y1={C.fBL.y} x2={C.bBL.x} y2={C.bBL.y} stroke="rgb(var(--primary) / 0.38)" strokeWidth="1" strokeDasharray="4 3" />
+      <line x1={C.bBL.x} y1={C.bBL.y} x2={C.bBR.x} y2={C.bBR.y} stroke="rgb(var(--primary) / 0.38)" strokeWidth="1" strokeDasharray="4 3" />
+
+      <g transform={`translate(${(F.x1 + F.x2) / 2 - 30}, ${F.y2 - 52})`}>
+        <rect x="0" y="0" width="60" height="30" rx="5" fill="rgb(var(--elevated) / 0.97)" stroke="rgb(var(--primary) / 0.9)" strokeWidth="1.3" />
+        <polyline points="14,17 23,25 46,9" fill="none" stroke="rgb(var(--primary))" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+      </g>
+    </>
+  );
+}
+
+function BallotLid() {
+  return (
+    <g transform={TOP_MATRIX}>
+      <rect
+        x={-LID_OVER + 2}
+        y={-LID_OVER + 4}
+        width={F.x2 - F.x1 + LID_OVER * 2}
+        height={F.y2 - F.y1 + LID_OVER * 2}
+        rx="4"
+        fill="rgb(0 0 0 / 0.35)"
+      />
+      <rect
+        x={-LID_OVER}
+        y={-LID_OVER}
+        width={F.x2 - F.x1 + LID_OVER * 2}
+        height={F.y2 - F.y1 + LID_OVER * 2}
+        rx="4"
+        fill="url(#bb-lid)"
+        stroke="rgb(var(--primary))"
+        strokeWidth="1.4"
+      />
+      <rect
+        x={-LID_OVER + 8}
+        y={-LID_OVER + 6}
+        width={F.x2 - F.x1 + LID_OVER * 2 - 16}
+        height="5"
+        rx="2"
+        fill="rgb(255 255 255 / 0.25)"
+      />
+      <rect
+        x={(F.x2 - F.x1) / 2 - 70}
+        y={(F.y2 - F.y1) / 2 - 10}
+        width="140"
+        height="20"
+        rx="6"
+        fill="url(#bb-slot)"
+        stroke="rgb(0 0 0 / 0.75)"
+        strokeWidth="2"
+      />
+      <rect
+        x={(F.x2 - F.x1) / 2 - 68}
+        y={(F.y2 - F.y1) / 2 - 8}
+        width="136"
+        height="4"
+        rx="2"
+        fill="rgb(0 0 0 / 0.7)"
+      />
+      <rect
+        x={(F.x2 - F.x1) / 2 - 68}
+        y={(F.y2 - F.y1) / 2 + 6}
+        width="136"
+        height="1.5"
+        rx="0.75"
+        fill="rgb(255 255 255 / 0.2)"
+      />
+    </g>
+  );
+}
+
+function FlyingBallot({ ballot, onDone }: { ballot: Flying; onDone: (id: number) => void }) {
+  return (
+    <m.g
+      initial={{ x: ballot.startX, y: ballot.startY, rotate: ballot.startRot, opacity: 0 }}
+      animate={{ x: SLOT.x, y: SLOT.y, rotate: 0, opacity: [0, 1, 1, 0] }}
+      transition={{
+        duration: 1.8,
+        x: { duration: 1.8, ease: 'easeOut' },
+        y: { duration: 1.8, ease: [0.55, 0.05, 0.85, 0.3] },
+        rotate: { duration: 1.8, ease: 'easeOut' },
+        opacity: { duration: 1.8, times: [0, 0.12, 0.9, 1] },
+      }}
+      onAnimationComplete={() => onDone(ballot.id)}
+    >
+      <g transform="translate(-22, -15)">
+        <rect x="0" y="0" width="44" height="30" rx="3" fill="rgb(var(--elevated))" stroke={`hsl(${ballot.hue} 55% 40%)`} strokeWidth="1" />
+        <rect x="0" y="0" width="44" height="8" rx="3" fill={`hsl(${ballot.hue} 75% 60%)`} />
+        <rect x="0" y="6" width="44" height="2" fill={`hsl(${ballot.hue} 60% 45%)`} />
+        <rect x="4" y="13" width="9" height="9" rx="1" fill={`hsl(${ballot.hue} 80% 55%)`} stroke={`hsl(${ballot.hue} 60% 40%)`} strokeWidth="0.6" />
+        <polyline points="5.5,17 8,19.5 12,14.5" fill="none" stroke="rgb(255 255 255)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <line x1="16" y1="15" x2="40" y2="15" stroke={`hsl(${ballot.hue} 25% 45%)`} strokeWidth="1.2" strokeLinecap="round" />
+        <line x1="16" y1="19" x2="34" y2="19" stroke={`hsl(${ballot.hue} 20% 55%)`} strokeWidth="1" strokeLinecap="round" />
+        <line x1="4" y1="25" x2="36" y2="25" stroke={`hsl(${ballot.hue} 20% 60%)`} strokeWidth="0.8" strokeLinecap="round" />
+      </g>
+    </m.g>
+  );
+}
+
+export function BallotBoxHero() {
+  const reduce = useReducedMotion();
+  const [flying, setFlying] = useState<Flying[]>([]);
+  const [counter, setCounter] = useState(1284);
+  const idRef = useRef(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const px = useMotionValue(0);
+  const py = useMotionValue(0);
+  const sx = useSpring(px, { stiffness: 140, damping: 18, mass: 0.6 });
+  const sy = useSpring(py, { stiffness: 140, damping: 18, mass: 0.6 });
+  const rotateY = useTransform(sx, [-1, 1], [-16, 16]);
+  const rotateX = useTransform(sy, [-1, 1], [10, -10]);
+
+  useEffect(() => {
+    if (reduce) return;
+    const spawn = () => {
+      const id = ++idRef.current;
+      setFlying((prev) => [
+        ...prev,
+        {
+          id,
+          startX: 120 + Math.random() * 360,
+          startY: 20 + Math.random() * 40,
+          startRot: (Math.random() - 0.5) * 140,
+          hue: 210 + Math.random() * 140,
+        },
+      ]);
+      setCounter((c) => c + 1);
+    };
+    spawn();
+    const t = window.setInterval(spawn, 1050);
+    return () => window.clearInterval(t);
+  }, [reduce]);
+
+  const onDone = (id: number) => setFlying((prev) => prev.filter((b) => b.id !== id));
+
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    const el = containerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const nx = ((e.clientX - r.left) / r.width) * 2 - 1;
+    const ny = ((e.clientY - r.top) / r.height) * 2 - 1;
+    px.set(Math.max(-1, Math.min(1, nx)));
+    py.set(Math.max(-1, Math.min(1, ny)));
+  };
+
+  const handlePointerLeave = () => {
+    px.set(0);
+    py.set(0);
+  };
+
+  return (
+    <section className="relative overflow-hidden">
+      <HeroBackdrop />
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-6 pb-24 pt-16 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:pt-24">
+        <HeroCopy counter={counter} />
+
+        <div
+          ref={containerRef}
+          onPointerMove={handlePointerMove}
+          onPointerLeave={handlePointerLeave}
+          className="relative aspect-[600/460] w-full max-w-[620px] justify-self-center"
+          style={{ perspective: 1100 }}
+        >
+          <m.svg
+            viewBox={`0 0 ${VB.w} ${VB.h}`}
+            className="h-full w-full"
+            style={{ rotateX, rotateY, transformStyle: 'preserve-3d' }}
+          >
+            <BallotDefs />
+            <BallotBoxGeometry />
+            <BallotLid />
+            {flying.map((b) => (
+              <FlyingBallot key={b.id} ballot={b} onDone={onDone} />
+            ))}
+          </m.svg>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/landing/CTASection.tsx
+++ b/client/src/components/landing/CTASection.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+export function CTASection() {
+  const { t } = useTranslation();
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-primary/90 to-accent/90 p-12 text-center shadow-glow">
+          <div className="absolute inset-0 -z-10 opacity-20" style={{
+            backgroundImage: 'radial-gradient(circle at 20% 20%, white 0, transparent 40%), radial-gradient(circle at 80% 70%, white 0, transparent 40%)',
+          }} />
+          <h2 className="font-display text-4xl font-semibold tracking-tight text-primary-fg sm:text-5xl">
+            {t('landing.cta.title')}
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-base text-primary-fg/90">{t('landing.cta.text')}</p>
+          <Link
+            to="/proposals/new"
+            className="mt-8 inline-flex h-12 items-center justify-center gap-2 rounded-full bg-bg px-6 text-sm font-semibold text-fg transition hover:-translate-y-0.5 hover:shadow-lg"
+          >
+            {t('landing.cta.button')}
+            <ArrowRight size={16} />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/landing/FeatureGrid.tsx
+++ b/client/src/components/landing/FeatureGrid.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { m } from 'framer-motion';
+import { ListOrdered, Users, Eye, ShieldCheck, Languages, Accessibility } from 'lucide-react';
+
+const icons = [ListOrdered, Users, Eye, ShieldCheck, Languages, Accessibility];
+
+export function FeatureGrid() {
+  const { t } = useTranslation();
+  const items = t('landing.features.items', { returnObjects: true }) as { title: string; text: string }[];
+
+  return (
+    <section className="py-24">
+      <div className="mx-auto max-w-7xl px-6">
+        <m.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="mx-auto max-w-2xl text-center font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl"
+        >
+          {t('landing.features.title')}
+        </m.h2>
+
+        <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((item, i) => {
+            const Icon = icons[i] ?? Users;
+            return (
+              <m.div
+                key={item.title}
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: i * 0.05 }}
+                className="rounded-2xl border border-border/70 bg-surface/70 p-6 transition hover:border-primary/40 hover:shadow-glow"
+              >
+                <div className="mb-4 inline-flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <Icon size={18} />
+                </div>
+                <h3 className="mb-1.5 font-display text-lg font-semibold text-fg">{item.title}</h3>
+                <p className="text-sm leading-relaxed text-muted">{item.text}</p>
+              </m.div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/landing/HeroCopy.tsx
+++ b/client/src/components/landing/HeroCopy.tsx
@@ -1,0 +1,89 @@
+import { m } from 'framer-motion';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, Sparkles } from 'lucide-react';
+
+export function HeroCopy({ counter }: { counter: number }) {
+  const { t } = useTranslation();
+  return (
+    <div className="relative z-10">
+      <m.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="mb-5 inline-flex items-center gap-2 rounded-full border border-border bg-surface/70 px-3 py-1.5 text-xs font-medium text-muted backdrop-blur"
+      >
+        <Sparkles size={14} className="text-primary" />
+        {t('landing.hero.eyebrow')}
+      </m.div>
+
+      <m.h1
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, delay: 0.05 }}
+        className="font-display text-5xl font-semibold leading-[1.05] tracking-tight text-fg sm:text-6xl lg:text-7xl"
+      >
+        {t('landing.hero.titleA')}
+        <br />
+        <span className="grad-text">{t('landing.hero.titleB')}</span>
+        <br />
+        {t('landing.hero.titleC')}
+      </m.h1>
+
+      <m.p
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, delay: 0.15 }}
+        className="mt-6 max-w-xl text-lg leading-relaxed text-muted"
+      >
+        {t('landing.hero.subtitle')}
+      </m.p>
+
+      <m.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7, delay: 0.25 }}
+        className="mt-8 flex flex-wrap items-center gap-4"
+      >
+        <Link
+          to="/proposals"
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-gradient-to-br from-primary to-accent px-6 text-sm font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+        >
+          {t('landing.hero.ctaPrimary')}
+          <ArrowRight size={16} />
+        </Link>
+        <a
+          href="#how"
+          className="inline-flex h-12 items-center justify-center rounded-full border border-border bg-surface px-6 text-sm font-semibold text-fg transition hover:border-primary hover:text-primary"
+        >
+          {t('landing.hero.ctaSecondary')}
+        </a>
+      </m.div>
+
+      <m.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.8, delay: 0.35 }}
+        className="mt-10 flex items-center gap-3 text-sm text-muted"
+      >
+        <span className="relative flex size-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+          <span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+        </span>
+        <span>
+          <span className="tabular-nums font-semibold text-fg">{counter.toLocaleString()}</span>{' '}
+          {t('landing.hero.counter')}
+        </span>
+      </m.div>
+    </div>
+  );
+}
+
+export function HeroBackdrop() {
+  return (
+    <div className="pointer-events-none absolute inset-0 -z-10">
+      <div className="absolute -left-40 top-0 size-[520px] rounded-full bg-primary/20 blur-3xl" />
+      <div className="absolute -right-40 top-40 size-[520px] rounded-full bg-accent/20 blur-3xl" />
+    </div>
+  );
+}

--- a/client/src/components/landing/HowItWorks.tsx
+++ b/client/src/components/landing/HowItWorks.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next';
+import { m } from 'framer-motion';
+import { FilePlus2, CheckCircle2, ListOrdered } from 'lucide-react';
+
+const icons = [FilePlus2, CheckCircle2, ListOrdered];
+
+export function HowItWorks() {
+  const { t } = useTranslation();
+  const steps = t('landing.how.steps', { returnObjects: true }) as { title: string; text: string }[];
+
+  return (
+    <section id="how" className="relative border-y border-border/60 bg-surface/30 py-24">
+      <div className="mx-auto max-w-7xl px-6">
+        <m.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="mx-auto max-w-2xl text-center font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl"
+        >
+          {t('landing.how.title')}
+        </m.h2>
+
+        <div className="mt-14 grid gap-6 md:grid-cols-3">
+          {steps.map((step, i) => {
+            const Icon = icons[i];
+            return (
+              <m.div
+                key={step.title}
+                initial={{ opacity: 0, y: 30 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.6, delay: i * 0.08 }}
+                className="group relative overflow-hidden rounded-2xl border border-border/70 bg-elevated p-8"
+              >
+                <div className="absolute -right-12 -top-12 size-40 rounded-full bg-primary/10 blur-3xl transition group-hover:bg-primary/20" />
+                <div className="relative">
+                  <div className="mb-5 flex size-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-accent text-primary-fg">
+                    <Icon size={22} />
+                  </div>
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">
+                    {String(i + 1).padStart(2, '0')}
+                  </div>
+                  <h3 className="mb-2 font-display text-xl font-semibold text-fg">{step.title}</h3>
+                  <p className="text-sm leading-relaxed text-muted">{step.text}</p>
+                </div>
+              </m.div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/landing/LandingShell.tsx
+++ b/client/src/components/landing/LandingShell.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import { HowItWorks } from './HowItWorks';
+import { FeatureGrid } from './FeatureGrid';
+import { CTASection } from './CTASection';
+
+export function LandingShell({ hero }: { hero: ReactNode }) {
+  return (
+    <>
+      {hero}
+      <HowItWorks />
+      <FeatureGrid />
+      <CTASection />
+    </>
+  );
+}

--- a/client/src/components/landing/RippleMapHero.tsx
+++ b/client/src/components/landing/RippleMapHero.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import { useTheme } from '../../theme/ThemeProvider';
+import { HeroBackdrop, HeroCopy } from './HeroCopy';
+
+interface Ripple {
+  x: number;
+  y: number;
+  t: number;
+  color: string;
+  max: number;
+}
+
+const COLORS = ['#6366F1', '#EC4899', '#10B981', '#F59E0B', '#06B6D4'];
+
+/**
+ * V6 — Ripple Map: a grid of voter dots where every few hundred ms a new
+ * vote sends a ripple expanding outward across the community. Dots light
+ * up as the rings pass over them.
+ */
+export function RippleMapHero() {
+  const reduce = useReducedMotion();
+  const { theme } = useTheme();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const ripplesRef = useRef<Ripple[]>([]);
+  const [counter, setCounter] = useState(8124);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = containerRef.current;
+    if (!canvas || !host) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const resize = () => {
+      const rect = host.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.cssText = `width: ${rect.width}px; height: ${rect.height}px;`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    let raf = 0;
+    let lastSpawn = 0;
+
+    const COLS = 28;
+    const ROWS = 20;
+
+    const step = (t: number) => {
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      ctx.clearRect(0, 0, w, h);
+
+      const pad = 24;
+      const gridW = w - pad * 2;
+      const gridH = h - pad * 2;
+      const dx = gridW / (COLS - 1);
+      const dy = gridH / (ROWS - 1);
+
+      if (!reduce && t - lastSpawn > 480) {
+        const gx = Math.floor(Math.random() * COLS);
+        const gy = Math.floor(Math.random() * ROWS);
+        ripplesRef.current.push({
+          x: pad + gx * dx,
+          y: pad + gy * dy,
+          t,
+          color: COLORS[Math.floor(Math.random() * COLORS.length)],
+          max: 120 + Math.random() * 80,
+        });
+        if (ripplesRef.current.length > 12) ripplesRef.current.shift();
+        lastSpawn = t;
+        setCounter((c) => c + 1);
+      }
+
+      // Draw grid of voter dots
+      const dotBase = theme === 'dark' ? 'rgba(148,163,184,0.38)' : 'rgba(55,65,95,0.55)';
+      for (let row = 0; row < ROWS; row++) {
+        for (let col = 0; col < COLS; col++) {
+          const px = pad + col * dx;
+          const py = pad + row * dy;
+
+          // Find the strongest ripple influence on this dot
+          let litColor: string | null = null;
+          let litAmount = 0;
+          for (const r of ripplesRef.current) {
+            const age = (t - r.t) / 1000;
+            const radius = age * 130;
+            if (radius > r.max) continue;
+            const d = Math.hypot(px - r.x, py - r.y);
+            const band = Math.abs(d - radius);
+            if (band < 18) {
+              const strength = (1 - band / 18) * (1 - radius / r.max);
+              if (strength > litAmount) {
+                litAmount = strength;
+                litColor = r.color;
+              }
+            }
+          }
+
+          ctx.beginPath();
+          if (litColor && litAmount > 0.05) {
+            ctx.fillStyle = litColor;
+            ctx.globalAlpha = Math.min(1, 0.35 + litAmount * 0.9);
+            ctx.arc(px, py, 1.6 + litAmount * 2.8, 0, Math.PI * 2);
+          } else {
+            ctx.fillStyle = dotBase;
+            ctx.globalAlpha = 1;
+            ctx.arc(px, py, 1.6, 0, Math.PI * 2);
+          }
+          ctx.fill();
+        }
+      }
+      ctx.globalAlpha = 1;
+
+      // Draw ripple rings
+      const alive: Ripple[] = [];
+      for (const r of ripplesRef.current) {
+        const age = (t - r.t) / 1000;
+        const radius = age * 130;
+        if (radius > r.max) continue;
+        const fade = 1 - radius / r.max;
+        ctx.strokeStyle = r.color;
+        ctx.globalAlpha = fade * 0.45;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(r.x, r.y, radius, 0, Math.PI * 2);
+        ctx.stroke();
+        // Inner glow ring
+        ctx.globalAlpha = fade * 0.18;
+        ctx.lineWidth = 6;
+        ctx.beginPath();
+        ctx.arc(r.x, r.y, radius, 0, Math.PI * 2);
+        ctx.stroke();
+        alive.push(r);
+      }
+      ctx.globalAlpha = 1;
+      ripplesRef.current = alive;
+
+      raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, [reduce, theme]);
+
+  return (
+    <section className="relative overflow-hidden">
+      <HeroBackdrop />
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-6 pb-24 pt-16 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:pt-24">
+        <HeroCopy counter={counter} />
+
+        <div
+          ref={containerRef}
+          className="relative aspect-[6/5] w-full max-w-[620px] justify-self-center"
+        >
+          <canvas ref={canvasRef} className="h-full w-full" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/landing/TallyMarksHero.tsx
+++ b/client/src/components/landing/TallyMarksHero.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import { m, useReducedMotion } from 'framer-motion';
+import { HeroBackdrop, HeroCopy } from './HeroCopy';
+
+/**
+ * Classic tally-mark vote counting. Four candidate rows; groups of five
+ * marks (four vertical + one diagonal crossing) accumulate as votes come
+ * in. The old-school way of counting votes on paper.
+ */
+
+const CANDIDATES = [
+  { name: 'Option A', hue: 230 },
+  { name: 'Option B', hue: 280 },
+  { name: 'Option C', hue: 330 },
+  { name: 'Option D', hue: 190 },
+];
+
+export function TallyMarksHero() {
+  const reduce = useReducedMotion();
+  const [counts, setCounts] = useState<number[]>([6, 4, 8, 3]);
+  const [counter, setCounter] = useState(1284);
+  const lastAdded = useRef<number>(-1);
+
+  useEffect(() => {
+    if (reduce) return;
+    const t = window.setInterval(() => {
+      const weights = [0.35, 0.2, 0.3, 0.15];
+      const r = Math.random();
+      let acc = 0;
+      let pick = 0;
+      for (let i = 0; i < weights.length; i++) {
+        acc += weights[i];
+        if (r < acc) {
+          pick = i;
+          break;
+        }
+      }
+      lastAdded.current = pick;
+      setCounts((c) => {
+        const next = [...c];
+        next[pick]++;
+        if (next.some((v) => v > 32)) return [0, 0, 0, 0];
+        return next;
+      });
+      setCounter((c) => c + 1);
+    }, 520);
+    return () => window.clearInterval(t);
+  }, [reduce]);
+
+  return (
+    <section className="relative overflow-hidden">
+      <HeroBackdrop />
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-6 pb-24 pt-16 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:pt-24">
+        <HeroCopy counter={counter} />
+        <div className="relative aspect-square w-full max-w-[560px] justify-self-center">
+          <div className="flex h-full w-full flex-col justify-center gap-5 p-2">
+            {CANDIDATES.map((c, i) => (
+              <TallyRow
+                key={c.name}
+                name={c.name}
+                hue={c.hue}
+                count={counts[i]}
+                flash={lastAdded.current === i}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TallyRow({
+  name,
+  hue,
+  count,
+  flash,
+}: {
+  name: string;
+  hue: number;
+  count: number;
+  flash: boolean;
+}) {
+  const groups = Math.floor(count / 5);
+  const remainder = count % 5;
+  const marks: { id: string; type: 'group' | 'partial'; count: number }[] = [];
+  for (let g = 0; g < groups; g++) marks.push({ id: `group-${g}`, type: 'group', count: 5 });
+  if (remainder > 0) marks.push({ id: 'partial', type: 'partial', count: remainder });
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-3">
+        <span
+          className="size-3 rounded-full"
+          style={{ background: `hsl(${hue} 80% 60%)`, boxShadow: `0 0 12px hsl(${hue} 90% 60%)` }}
+        />
+        <span className="text-sm font-semibold text-fg">{name}</span>
+        <m.span
+          key={count}
+          initial={flash ? { scale: 1.4, color: `hsl(${hue} 85% 60%)` } : false}
+          animate={{ scale: 1, color: 'rgb(var(--muted))' }}
+          transition={{ duration: 0.35 }}
+          className="ml-auto tabular-nums text-xs font-semibold"
+        >
+          {count}
+        </m.span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        {marks.map((mark) => (
+          <TallyGroup key={mark.id} hue={hue} count={mark.count} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TallyGroup({ hue, count }: { hue: number; count: number }) {
+  const color = `hsl(${hue} 80% 65%)`;
+  return (
+    <svg width="44" height="36" viewBox="0 0 44 36">
+      {['tally-1', 'tally-2', 'tally-3', 'tally-4'].map((tag, i) =>
+        i < Math.min(count, 4) ? (
+          <m.line
+            key={tag}
+            x1={4 + i * 8}
+            y1="4"
+            x2={4 + i * 8}
+            y2="32"
+            stroke={color}
+            strokeWidth="3"
+            strokeLinecap="round"
+            initial={{ pathLength: 0, opacity: 0 }}
+            animate={{ pathLength: 1, opacity: 1 }}
+            transition={{ duration: 0.25, delay: i * 0.04 }}
+          />
+        ) : null,
+      )}
+      {count >= 5 && (
+        <m.line
+          x1="0"
+          y1="30"
+          x2="40"
+          y2="6"
+          stroke={color}
+          strokeWidth="3"
+          strokeLinecap="round"
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ duration: 0.3 }}
+        />
+      )}
+    </svg>
+  );
+}

--- a/client/src/components/landing/VoicesChorusHero.tsx
+++ b/client/src/components/landing/VoicesChorusHero.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import { useTheme } from '../../theme/ThemeProvider';
+import { HeroBackdrop, HeroCopy } from './HeroCopy';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  column: number;
+  life: number;
+}
+
+const COLUMNS = [
+  { label: 'Option A', color: '#6366F1' },
+  { label: 'Option B', color: '#EC4899' },
+  { label: 'Option C', color: '#10B981' },
+  { label: 'Option D', color: '#F59E0B' },
+];
+
+/**
+ * V3 — Voices into a Chorus: particles representing voters drift in from
+ * the edges, gravitate toward one of four option columns, and dissolve
+ * into growing bars. A recurring "reset" empties the chorus.
+ */
+export function VoicesChorusHero() {
+  const reduce = useReducedMotion();
+  const { theme } = useTheme();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const heightsRef = useRef<number[]>([0, 0, 0, 0]);
+  const [counter, setCounter] = useState(3892);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = containerRef.current;
+    if (!canvas || !host) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const resize = () => {
+      const rect = host.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.cssText = `width: ${rect.width}px; height: ${rect.height}px;`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    let raf = 0;
+    let lastSpawn = 0;
+    let lastReset = performance.now();
+
+    const spawn = (w: number, h: number) => {
+      const edge = Math.floor(Math.random() * 3);
+      const column = Math.floor(Math.random() * 4);
+      let x = 0;
+      let y = 0;
+      if (edge === 0) {
+        x = Math.random() * w;
+        y = -20;
+      } else if (edge === 1) {
+        x = -20;
+        y = Math.random() * h * 0.6;
+      } else {
+        x = w + 20;
+        y = Math.random() * h * 0.6;
+      }
+      particlesRef.current.push({
+        x,
+        y,
+        vx: 0,
+        vy: 0,
+        r: 2 + Math.random() * 2.5,
+        column,
+        life: 0,
+      });
+    };
+
+    const step = (t: number) => {
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      ctx.clearRect(0, 0, w, h);
+
+      if (!reduce) {
+        if (t - lastSpawn > 55) {
+          for (let i = 0; i < 3; i++) spawn(w, h);
+          lastSpawn = t;
+        }
+        if (t - lastReset > 9000) {
+          heightsRef.current = heightsRef.current.map((v) => v * 0.2);
+          lastReset = t;
+        }
+      }
+
+      const colWidth = w / 4;
+      const baseY = h - 20;
+
+      // Draw column bars first (behind particles)
+      COLUMNS.forEach((col, i) => {
+        const barHeight = Math.min(heightsRef.current[i], h - 80);
+        const bx = i * colWidth + colWidth * 0.18;
+        const bw = colWidth * 0.64;
+        // glow
+        ctx.fillStyle = col.color + '25';
+        ctx.beginPath();
+        roundRect(ctx, bx - 6, baseY - barHeight - 6, bw + 12, barHeight + 12, 14);
+        ctx.fill();
+        // bar gradient
+        const grad = ctx.createLinearGradient(0, baseY - barHeight, 0, baseY);
+        grad.addColorStop(0, col.color);
+        grad.addColorStop(1, col.color + 'aa');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        roundRect(ctx, bx, baseY - barHeight, bw, Math.max(barHeight, 2), 10);
+        ctx.fill();
+        // label
+        ctx.fillStyle = theme === 'dark' ? 'rgba(237,240,252,0.72)' : 'rgba(15,15,35,0.72)';
+        ctx.font = '600 10px "Space Grotesk", system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(col.label.toUpperCase(), bx + bw / 2, baseY + 14);
+      });
+
+      // Update + draw particles
+      const alive: Particle[] = [];
+      for (const p of particlesRef.current) {
+        const targetX = p.column * colWidth + colWidth / 2;
+        const targetY = baseY - Math.min(heightsRef.current[p.column], h - 90) - 8;
+        const dx = targetX - p.x;
+        const dy = targetY - p.y;
+        const dist = Math.hypot(dx, dy);
+        p.vx += (dx / (dist + 1)) * 0.35;
+        p.vy += (dy / (dist + 1)) * 0.35;
+        p.vx *= 0.94;
+        p.vy *= 0.94;
+        p.x += p.vx;
+        p.y += p.vy;
+        p.life += 1;
+
+        const col = COLUMNS[p.column];
+        ctx.fillStyle = col.color;
+        ctx.globalAlpha = Math.min(1, p.life / 6);
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+        // trail
+        ctx.strokeStyle = col.color + '55';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(p.x, p.y);
+        ctx.lineTo(p.x - p.vx * 2, p.y - p.vy * 2);
+        ctx.stroke();
+
+        if (dist < 10) {
+          heightsRef.current[p.column] += 1.4;
+          continue;
+        }
+        if (p.life < 400) alive.push(p);
+      }
+      particlesRef.current = alive;
+
+      if (Math.floor(t / 400) % 2 === 0 && Math.random() < 0.1) setCounter((c) => c + 1);
+
+      raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, [reduce, theme]);
+
+  return (
+    <section className="relative overflow-hidden">
+      <HeroBackdrop />
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-6 pb-24 pt-16 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:pt-24">
+        <HeroCopy counter={counter} />
+
+        <div
+          ref={containerRef}
+          className="relative aspect-square w-full max-w-[560px] justify-self-center"
+        >
+          <canvas ref={canvasRef} className="h-full w-full" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+}

--- a/client/src/components/landing/VoteBloomHero.tsx
+++ b/client/src/components/landing/VoteBloomHero.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import { useTheme } from '../../theme/ThemeProvider';
+import { HeroBackdrop, HeroCopy } from './HeroCopy';
+
+/**
+ * V5 — Vote Bloom: a radial flower of six petals (one per option). Votes
+ * arrive as glowing particles at the outer edge of a petal, glide inward
+ * along its axis, and on reaching the core are "absorbed" — growing the
+ * petal and emitting a radial pulse. Combines the tally-counting of v4,
+ * the converging particles of v2, the radial propagation of v3, and the
+ * central focus of v1 into one unified bloom.
+ */
+
+const PETALS = [
+  { label: 'A', color: '#6366f1' },
+  { label: 'B', color: '#ec4899' },
+  { label: 'C', color: '#10b981' },
+  { label: 'D', color: '#f59e0b' },
+  { label: 'E', color: '#06b6d4' },
+  { label: 'F', color: '#a855f7' },
+];
+
+interface Particle {
+  petal: number;
+  d: number; // normalized position along the petal (1 = tip, 0 = core)
+  speed: number;
+  color: string;
+  size: number;
+}
+
+interface Pulse {
+  born: number;
+  color: string;
+}
+
+export function VoteBloomHero() {
+  const reduce = useReducedMotion();
+  const { theme } = useTheme();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const votesRef = useRef<number[]>([12, 8, 15, 6, 10, 4]);
+  const pulsesRef = useRef<Pulse[]>([]);
+  const rotRef = useRef(0);
+  const coreFlashRef = useRef(0);
+  const [counter, setCounter] = useState(2468);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = containerRef.current;
+    if (!canvas || !host) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const resize = () => {
+      const rect = host.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.cssText = `width: ${rect.width}px; height: ${rect.height}px;`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    let raf = 0;
+    let lastSpawn = 0;
+    let lastTime = performance.now();
+
+    const step = (t: number) => {
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      const cx = w / 2;
+      const cy = h / 2;
+      const dt = Math.min(64, t - lastTime);
+      lastTime = t;
+
+      ctx.clearRect(0, 0, w, h);
+
+      if (!reduce) rotRef.current += dt * 0.00014;
+      coreFlashRef.current = Math.max(0, coreFlashRef.current - dt / 450);
+
+      // Spawn a new incoming vote
+      if (!reduce && t - lastSpawn > 220) {
+        lastSpawn = t;
+        const petal = Math.floor(Math.random() * PETALS.length);
+        particlesRef.current.push({
+          petal,
+          d: 1.0,
+          speed: 0.00055 + Math.random() * 0.00025,
+          color: PETALS[petal].color,
+          size: 1.8 + Math.random() * 1.6,
+        });
+        setCounter((c) => c + 1);
+      }
+
+      // Periodic soft normalization so a fast-growing petal doesn't dominate forever
+      if (Math.random() < 0.0015) {
+        votesRef.current = votesRef.current.map((v) => Math.max(1, Math.floor(v * 0.82)));
+      }
+
+      const coreR = Math.min(w, h) * 0.09;
+      const maxR = Math.min(w, h) * 0.46;
+      const maxVotes = Math.max(20, ...votesRef.current);
+      const petalLength = (i: number) =>
+        coreR + 10 + (votesRef.current[i] / maxVotes) * (maxR - coreR - 24);
+
+      // ---- background soft halo ----
+      const halo = ctx.createRadialGradient(cx, cy, 0, cx, cy, maxR);
+      halo.addColorStop(
+        0,
+        theme === 'dark' ? 'rgba(99,102,241,0.18)' : 'rgba(79,70,229,0.12)',
+      );
+      halo.addColorStop(1, 'rgba(99,102,241,0)');
+      ctx.fillStyle = halo;
+      ctx.beginPath();
+      ctx.arc(cx, cy, maxR, 0, Math.PI * 2);
+      ctx.fill();
+
+      // ---- outer guide ring (dashed) ----
+      ctx.strokeStyle = theme === 'dark' ? 'rgba(180,190,255,0.18)' : 'rgba(79,70,229,0.22)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 6]);
+      ctx.beginPath();
+      ctx.arc(cx, cy, maxR - 6, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // ---- radial pulses (ripples from the core) ----
+      const alivePulses: Pulse[] = [];
+      for (const p of pulsesRef.current) {
+        const age = (t - p.born) / 1000;
+        const radius = coreR + age * 260;
+        if (radius > maxR + 40) continue;
+        const fade = 1 - (radius - coreR) / (maxR - coreR);
+        ctx.strokeStyle = p.color;
+        ctx.globalAlpha = Math.max(0, fade) * 0.4;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = Math.max(0, fade) * 0.18;
+        ctx.lineWidth = 8;
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+        ctx.stroke();
+        alivePulses.push(p);
+      }
+      ctx.globalAlpha = 1;
+      pulsesRef.current = alivePulses;
+
+      // ---- draw petals ----
+      const rot = rotRef.current;
+      PETALS.forEach((pt, i) => {
+        const angle = (i / PETALS.length) * Math.PI * 2 + rot;
+        const length = petalLength(i);
+
+        ctx.save();
+        ctx.translate(cx, cy);
+        ctx.rotate(angle);
+
+        const halfWidth = Math.min(length * 0.32, 38);
+
+        // petal body gradient
+        const petalGrad = ctx.createLinearGradient(coreR, 0, length, 0);
+        petalGrad.addColorStop(0, pt.color + 'f2');
+        petalGrad.addColorStop(0.75, pt.color + '55');
+        petalGrad.addColorStop(1, pt.color + '10');
+        ctx.fillStyle = petalGrad;
+
+        ctx.beginPath();
+        ctx.moveTo(coreR, 0);
+        ctx.bezierCurveTo(
+          coreR + length * 0.25,
+          -halfWidth,
+          coreR + length * 0.7,
+          -halfWidth * 0.6,
+          length,
+          0,
+        );
+        ctx.bezierCurveTo(
+          coreR + length * 0.7,
+          halfWidth * 0.6,
+          coreR + length * 0.25,
+          halfWidth,
+          coreR,
+          0,
+        );
+        ctx.closePath();
+        ctx.fill();
+
+        // outline
+        ctx.strokeStyle = pt.color;
+        ctx.globalAlpha = 0.7;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+
+        // midrib
+        ctx.strokeStyle = pt.color;
+        ctx.globalAlpha = 0.55;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(coreR + 2, 0);
+        ctx.lineTo(length - 4, 0);
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+
+        ctx.restore();
+
+        // vote count label at tip (un-rotated so it reads normally)
+        const tipX = cx + Math.cos(angle) * (length + 18);
+        const tipY = cy + Math.sin(angle) * (length + 18);
+        ctx.fillStyle = pt.color;
+        ctx.beginPath();
+        ctx.arc(tipX, tipY, 14, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = theme === 'dark' ? 'rgba(15,15,35,0.6)' : 'rgba(255,255,255,0.9)';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '700 11px "Space Grotesk", system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(String(votesRef.current[i]), tipX, tipY + 0.5);
+      });
+
+      // ---- update + draw particles ----
+      const alive: Particle[] = [];
+      for (const p of particlesRef.current) {
+        p.d -= p.speed * dt;
+        if (p.d <= 0) {
+          votesRef.current[p.petal]++;
+          pulsesRef.current.push({ born: t, color: p.color });
+          coreFlashRef.current = 1;
+          continue;
+        }
+        const petalAngle = (p.petal / PETALS.length) * Math.PI * 2 + rot;
+        const r = coreR + (petalLength(p.petal) - coreR) * p.d;
+        const px = cx + Math.cos(petalAngle) * r;
+        const py = cy + Math.sin(petalAngle) * r;
+
+        ctx.shadowColor = p.color;
+        ctx.shadowBlur = 16;
+        ctx.fillStyle = p.color;
+        ctx.beginPath();
+        ctx.arc(px, py, p.size, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.shadowBlur = 0;
+
+        alive.push(p);
+      }
+      particlesRef.current = alive;
+
+      // ---- central core ----
+      const flashBoost = 1 + coreFlashRef.current * 0.6;
+      const coreGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, coreR * 1.8);
+      if (theme === 'dark') {
+        coreGrad.addColorStop(0, `rgba(224,231,255,${0.95 * flashBoost})`);
+        coreGrad.addColorStop(0.35, 'rgba(129,140,248,0.7)');
+        coreGrad.addColorStop(1, 'rgba(129,140,248,0)');
+      } else {
+        coreGrad.addColorStop(0, `rgba(255,255,255,${0.98 * flashBoost})`);
+        coreGrad.addColorStop(0.35, 'rgba(79,70,229,0.65)');
+        coreGrad.addColorStop(1, 'rgba(79,70,229,0)');
+      }
+      ctx.fillStyle = coreGrad;
+      ctx.beginPath();
+      ctx.arc(cx, cy, coreR * 1.8, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = theme === 'dark' ? '#f8fafc' : '#ffffff';
+      ctx.strokeStyle = theme === 'dark' ? '#6366f1' : '#4f46e5';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(cx, cy, coreR, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+
+      const total = votesRef.current.reduce((s, v) => s + v, 0);
+      ctx.fillStyle = theme === 'dark' ? '#4f46e5' : '#4f46e5';
+      ctx.font = '800 22px "Space Grotesk", system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(total), cx, cy - 4);
+      ctx.fillStyle = theme === 'dark' ? 'rgba(79,70,229,0.75)' : 'rgba(79,70,229,0.75)';
+      ctx.font = '600 9px "Space Grotesk", system-ui, sans-serif';
+      ctx.fillText('VOTES', cx, cy + 14);
+
+      raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, [reduce, theme]);
+
+  return (
+    <section className="relative overflow-hidden">
+      <HeroBackdrop />
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-6 pb-24 pt-16 lg:grid-cols-[1.1fr_1fr] lg:items-center lg:pt-24">
+        <HeroCopy counter={counter} />
+        <div
+          ref={containerRef}
+          className="relative aspect-square w-full max-w-[560px] justify-self-center"
+        >
+          <canvas ref={canvasRef} className="h-full w-full" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function subscribe() {
+  return () => {};
+}
+
+function getYear() {
+  return new Date().getFullYear();
+}
+
+function getServerYear() {
+  return 0;
+}
+
+export function Footer() {
+  const { t } = useTranslation();
+  const year = useSyncExternalStore(subscribe, getYear, getServerYear);
+
+  return (
+    <footer className="border-t border-border/60 bg-surface/40">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-8 text-sm text-muted md:flex-row">
+        <div className="flex items-center gap-2">
+          <span className="font-display text-fg">{t('brand')}</span>
+          <span>· {t('landing.footer.tagline')}</span>
+        </div>
+        <div suppressHydrationWarning>
+          {year > 0 && <>© {year} · </>}
+          {t('landing.footer.rights')}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,0 +1,43 @@
+import { NavLink, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { LanguageSwitcher } from '../LanguageSwitcher';
+import { ThemeToggle } from '../ThemeToggle';
+import { Vote } from 'lucide-react';
+
+export function Header() {
+  const { t } = useTranslation();
+  const linkBase =
+    'text-sm font-medium transition hover:text-primary';
+  return (
+    <header className="sticky top-0 z-30 border-b border-border/60 bg-bg/70 backdrop-blur-lg">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
+        <Link to="/" className="flex items-center gap-2 text-fg">
+          <span className="flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-accent text-primary-fg shadow-glow">
+            <Vote size={18} />
+          </span>
+          <span className="font-display text-lg font-semibold tracking-tight">{t('brand')}</span>
+        </Link>
+
+        <nav className="hidden items-center gap-8 md:flex">
+          <NavLink to="/" end className={({ isActive }) => `${linkBase} ${isActive ? 'text-primary' : 'text-fg'}`}>
+            {t('nav.home')}
+          </NavLink>
+          <NavLink to="/organizations" className={({ isActive }) => `${linkBase} ${isActive ? 'text-primary' : 'text-fg'}`}>
+            {t('org.title')}
+          </NavLink>
+          <NavLink to="/proposals" className={({ isActive }) => `${linkBase} ${isActive ? 'text-primary' : 'text-fg'}`}>
+            {t('nav.proposals')}
+          </NavLink>
+          <NavLink to="/proposals/new" className={({ isActive }) => `${linkBase} ${isActive ? 'text-primary' : 'text-fg'}`}>
+            {t('nav.newProposal')}
+          </NavLink>
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -1,0 +1,28 @@
+import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
+import i18n from 'i18next';
+
+import en from './locales/en.json';
+import es from './locales/es.json';
+import ca from './locales/ca.json';
+
+export const resources = {
+    en: { translation: en },
+    es: { translation: es },
+    ca: { translation: ca },
+} as const;
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'en',
+    supportedLngs: ['en', 'es', 'ca'],
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'lang',
+    },
+  });

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -1,5 +1,62 @@
 {
   "brand": "Demochain",
+  "nav": {
+    "home": "Inici",
+    "proposals": "Propostes",
+    "newProposal": "Nova proposta",
+    "howItWorks": "Com funciona"
+  },
+  "theme": {
+    "toggle": "Canvia el tema",
+    "light": "Clar",
+    "dark": "Fosc"
+  },
+  "language": {
+    "label": "Idioma",
+    "en": "Anglès",
+    "es": "Castellà",
+    "ca": "Català"
+  },
+  "landing": {
+    "hero": {
+      "eyebrow": "Vot preferencial per a tothom",
+      "titleA": "Ordena.",
+      "titleB": "Decideix.",
+      "titleC": "Verifica.",
+      "subtitle": "Proposa eleccions, ordena les teves preferències i confia en el resultat. Una plataforma oberta on la comunitat decideix què importa — i com es mesura.",
+      "ctaPrimary": "Explora propostes",
+      "ctaSecondary": "Com funciona",
+      "counter": "veus emeses avui"
+    },
+    "how": {
+      "title": "Tres passos, un resultat clar",
+      "steps": [
+        { "title": "Proposa", "text": "Qualsevol persona pot proposar una elecció — un títol, dates i les opcions que els votants ordenaran." },
+        { "title": "Aprova", "text": "La comunitat vota per aprovar-la. Si arriba als dos terços, s'obre en les dates fixades." },
+        { "title": "Ordena i decideix", "text": "Els votants arrosseguen les opcions en el seu ordre de preferència. La guanyadora reflecteix el que realment vol la majoria." }
+      ]
+    },
+    "features": {
+      "title": "Fet per a votants, no per a proveïdors",
+      "items": [
+        { "title": "Vot preferencial", "text": "Ordena tantes opcions com vulguis. Sense vots perduts ni efecte spoiler." },
+        { "title": "Aprovació comunitària", "text": "Les propostes només esdevenen eleccions amb dos terços de suport — cap administrador decideix sol." },
+        { "title": "Resultats oberts", "text": "Cada classificació és pública. Veus el guanyador, els segons i com d'ajustada va ser la cursa." },
+        { "title": "Verificable de manera independent", "text": "Cada papereta rep un rebut que qualsevol pot comprovar — ancorat a Algorand perquè el recompte no es pugui reescriure." },
+        { "title": "Multilingüe", "text": "Vota en anglès, castellà o català. La teva veu, la teva llengua." },
+        { "title": "Accessible de mena", "text": "Classificació amb teclat, mode fosc i suport de moviment reduït." }
+      ]
+    },
+    "cta": {
+      "title": "A punt per deixar decidir la gent?",
+      "text": "Redacta una proposta en minuts. La comunitat s'encarrega de la resta.",
+      "button": "Crea una proposta"
+    },
+    "footer": {
+      "tagline": "Eines democràtiques, construïdes obertament.",
+      "rights": "Tots els drets reservats."
+    }
+  },
   "errors": {
     "proposal": {
       "empty-title": "El títol no pot estar buit",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -1,5 +1,62 @@
 {
   "brand": "Demochain",
+  "nav": {
+    "home": "Home",
+    "proposals": "Proposals",
+    "newProposal": "New proposal",
+    "howItWorks": "How it works"
+  },
+  "theme": {
+    "toggle": "Toggle theme",
+    "light": "Light",
+    "dark": "Dark"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "es": "Spanish",
+    "ca": "Catalan"
+  },
+  "landing": {
+    "hero": {
+      "eyebrow": "Ranked-choice voting for everyone",
+      "titleA": "Rank.",
+      "titleB": "Decide.",
+      "titleC": "Verify.",
+      "subtitle": "Propose elections, rank your choices, and trust the outcome. An open platform where the community decides what matters — and how it's measured.",
+      "ctaPrimary": "Explore proposals",
+      "ctaSecondary": "How it works",
+      "counter": "voices cast today"
+    },
+    "how": {
+      "title": "Three steps, one clear outcome",
+      "steps": [
+        { "title": "Propose", "text": "Anyone can propose an election — a title, dates, and the options voters will rank." },
+        { "title": "Approve", "text": "The community votes to approve it. Reach two thirds and it goes live on the dates you set." },
+        { "title": "Rank & decide", "text": "Voters drag options into their order of preference. The winner reflects what the majority actually wants." }
+      ]
+    },
+    "features": {
+      "title": "Built around voters, not vendors",
+      "items": [
+        { "title": "Preferential voting", "text": "Rank as many options as you like. No wasted votes, no spoiler effect." },
+        { "title": "Community gated", "text": "Proposals only become elections with two-thirds community approval — no single admin decides." },
+        { "title": "Open results", "text": "Every ranking is public. See the winner, the runners-up, and how close the race actually was." },
+        { "title": "Independently verifiable", "text": "Each ballot gets a receipt anyone can check — anchored on Algorand so the tally cannot be rewritten." },
+        { "title": "Multi-lingual", "text": "Vote in English, Spanish, or Catalan. Your voice, your language." },
+        { "title": "Accessible by design", "text": "Keyboard-friendly ranking, dark mode, reduced-motion support." }
+      ]
+    },
+    "cta": {
+      "title": "Ready to let people decide?",
+      "text": "Draft a proposal in minutes. The community takes it from there.",
+      "button": "Start a proposal"
+    },
+    "footer": {
+      "tagline": "Democratic tools, openly built.",
+      "rights": "All rights reserved."
+    }
+  },
   "errors": {
     "proposal": {
       "empty-title": "Title cannot be empty",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -1,5 +1,62 @@
 {
   "brand": "Demochain",
+  "nav": {
+    "home": "Inicio",
+    "proposals": "Propuestas",
+    "newProposal": "Nueva propuesta",
+    "howItWorks": "Cómo funciona"
+  },
+  "theme": {
+    "toggle": "Cambiar tema",
+    "light": "Claro",
+    "dark": "Oscuro"
+  },
+  "language": {
+    "label": "Idioma",
+    "en": "Inglés",
+    "es": "Español",
+    "ca": "Catalán"
+  },
+  "landing": {
+    "hero": {
+      "eyebrow": "Voto preferencial para todos",
+      "titleA": "Ordena.",
+      "titleB": "Decide.",
+      "titleC": "Verifica",
+      "subtitle": "Propón elecciones, ordena tus preferencias y confía en el resultado. Una plataforma abierta donde la comunidad decide qué importa — y cómo se mide.",
+      "ctaPrimary": "Ver propuestas",
+      "ctaSecondary": "Cómo funciona",
+      "counter": "voces emitidas hoy"
+    },
+    "how": {
+      "title": "Tres pasos, un resultado claro",
+      "steps": [
+        { "title": "Propón", "text": "Cualquiera puede proponer una elección — título, fechas y las opciones que los votantes clasificarán." },
+        { "title": "Aprueba", "text": "La comunidad vota para aprobarla. Si alcanza los dos tercios, se abre en las fechas fijadas." },
+        { "title": "Ordena y decide", "text": "Los votantes arrastran las opciones a su orden de preferencia. La ganadora refleja lo que la mayoría realmente quiere." }
+      ]
+    },
+    "features": {
+      "title": "Pensado para votantes, no para proveedores",
+      "items": [
+        { "title": "Voto preferencial", "text": "Clasifica tantas opciones como quieras. Sin votos perdidos ni efecto spoiler." },
+        { "title": "Aprobación comunitaria", "text": "Las propuestas solo se convierten en elecciones con dos tercios de apoyo — no decide un solo administrador." },
+        { "title": "Resultados abiertos", "text": "Cada clasificación es pública. Ve al ganador, a los segundos y cómo de reñida estuvo la carrera." },
+        { "title": "Verificable de forma independiente", "text": "Cada papeleta recibe un recibo que cualquiera puede comprobar — anclado en Algorand para que el recuento no pueda reescribirse." },
+        { "title": "Multilingüe", "text": "Vota en inglés, español o catalán. Tu voz, tu idioma." },
+        { "title": "Accesible por diseño", "text": "Clasificación con teclado, modo oscuro y soporte de movimiento reducido." }
+      ]
+    },
+    "cta": {
+      "title": "¿Listo para dejar decidir a la gente?",
+      "text": "Redacta una propuesta en minutos. La comunidad se encarga del resto.",
+      "button": "Crear propuesta"
+    },
+    "footer": {
+      "tagline": "Herramientas democráticas, construidas en abierto.",
+      "rights": "Todos los derechos reservados."
+    }
+  },
   "errors": {
     "proposal": {
       "empty-title": "El título no puede estar vacío",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,65 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: 237 241 249;
+  --surface: 255 255 255;
+  --elevated: 248 250 252;
+  --border: 203 213 225;
+  --fg: 15 23 42;
+  --muted: 100 116 139;
+  --primary: 29 78 216;
+  --primary-fg: 255 255 255;
+  --accent: 202 138 4;
+}
+
+.dark {
+  --bg: 9 14 28;
+  --surface: 17 25 44;
+  --elevated: 23 33 58;
+  --border: 40 55 88;
+  --fg: 226 232 240;
+  --muted: 148 163 184;
+  --primary: 96 165 250;
+  --primary-fg: 10 15 28;
+  --accent: 250 204 21;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  @apply bg-bg text-fg font-sans antialiased;
+  font-feature-settings: 'cv11', 'ss01';
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgb(var(--border)); border-radius: 8px; }
+::-webkit-scrollbar-thumb:hover { background: rgb(var(--muted)); }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+.grad-text {
+  background: linear-gradient(120deg, rgb(var(--primary)), rgb(var(--accent)));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.glass {
+  background: rgb(var(--surface) / 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgb(var(--border) / 0.8);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import {RouterProvider} from 'react-router-dom';
+import {createRoot} from 'react-dom/client';
+
+import {ThemeProvider} from './theme/ThemeProvider';
+import {router} from './router';
+
+import './index.css';
+import './i18n';
+
+createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+        <ThemeProvider>
+            <RouterProvider router={router}/>
+        </ThemeProvider>
+    </React.StrictMode>,
+);

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+import { VoicesChorusHero } from '@/components/landing/VoicesChorusHero';
+import { TallyMarksHero } from '@/components/landing/TallyMarksHero';
+import { BallotBoxHero } from '@/components/landing/BallotBoxHero';
+import { RippleMapHero } from '@/components/landing/RippleMapHero';
+import { VoteBloomHero } from '@/components/landing/VoteBloomHero';
+import { LandingShell } from '@/components/landing/LandingShell';
+
+const HEROES = [BallotBoxHero, VoicesChorusHero, RippleMapHero, TallyMarksHero, VoteBloomHero];
+
+export function LandingPage() {
+  const Hero = useMemo(() => HEROES[Math.floor(Math.random() * HEROES.length)], []);
+
+  return <LandingShell hero={<Hero />} />;
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,0 +1,13 @@
+import { createBrowserRouter } from 'react-router-dom';
+
+import { LandingPage } from './pages/LandingPage';
+import App from './App';
+
+export const router = createBrowserRouter([
+  {
+    element: <App />,
+    children: [
+      { path: '/', element: <LandingPage /> }
+    ],
+  },
+]);

--- a/client/src/theme/ThemeProvider.tsx
+++ b/client/src/theme/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, use, useCallback, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getInitial(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const saved = localStorage.getItem('theme');
+  if (saved === 'light' || saved === 'dark') return saved;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitial);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
+  const toggle = useCallback(() => setThemeState((t) => (t === 'dark' ? 'light' : 'dark')), []);
+
+  return <ThemeContext.Provider value={{ theme, setTheme, toggle }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = use(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside ThemeProvider');
+  return ctx;
+}

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -4,6 +4,17 @@ export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   darkMode: 'class',
   theme: {
+    screens: {
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
+      // Reduced-motion variant for accessibility (WCAG 2.3.3).
+      // Pair with `useReducedMotion` from framer-motion and the @media
+      // (prefers-reduced-motion: reduce) query in index.css.
+      'motion-reduce': { raw: '(prefers-reduced-motion: reduce)' },
+    },
     extend: {
       colors: {
         bg: 'rgb(var(--bg) / <alpha-value>)',

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
   server: {
     host: true,
     port: 5173,


### PR DESCRIPTION
Implementa la pàgina d'inici (landing page) de l'aplicació Demochain. Inclou un selector de tema clar/fosc persistent, un canviador d'idioma (català, castellà, anglès) basat en i18next, i seccions informatives de la plataforma: hero animat, graella de funcionalitats, funcionament pas a pas i crida a l'acció.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #389 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
