### PR TITLE
feat(client): schemas i tipus de domini per a organitzacions

### DIFF
--- a/client/src/algorand/mappers.ts
+++ b/client/src/algorand/mappers.ts
@@ -1,0 +1,17 @@
+import type { OnChainOrganization } from './wire';
+import type { Organization } from '@/domain';
+import { asOrganizationId, asAddress } from '@/domain';
+
+export function mapToOrganization(
+  id: number,
+  onChain: OnChainOrganization,
+  memberCount: number,
+): Organization {
+  return {
+    id: asOrganizationId(id),
+    name: onChain.name,
+    description: onChain.description,
+    organizer: asAddress(onChain.organizer),
+    memberCount,
+  };
+}

--- a/client/src/algorand/wire.ts
+++ b/client/src/algorand/wire.ts
@@ -1,0 +1,13 @@
+// Tipus de wire — la forma de les estructures ARC-56 descodificades per algosdk. Aquests existeixen
+// només per connectar la codificació on-chain als tipus de domini de 'src/domain/'.
+// El codi fora de 'src/algorand/' no hauria d'importar-se d'aquí; hauria de consumir de 'src/domain/'.
+
+// ARC-56 Organization struct: (uint64, string, string, address, uint32)
+export interface OnChainOrganization {
+  orgId: number;
+  name: string;
+  description: string;
+  /** Adreça Algorand (58-char base32). */
+  organizer: string;
+  memberCount: number;
+}

--- a/client/src/domain/address.test.ts
+++ b/client/src/domain/address.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'bun:test';
+import { addressSchema, asAddress, isAddress, parseAddressList } from './address';
+
+const VALID = 'A'.repeat(58);
+const B_ADDR = 'B'.repeat(58);
+const C_ADDR = 'C'.repeat(58);
+const SHORT = 'A'.repeat(57);
+const INVALID_CHAR = 'A'.repeat(57) + '1';
+
+function errorMessages(result: { success: boolean; error?: { issues: { message: string }[] } }): string[] {
+  if (result.success || !result.error) return [];
+  return result.error.issues.map((i) => i.message);
+}
+
+describe('addressSchema', () => {
+  it('passa amb una adreça base32 vàlida de 58 caràcters', () => {
+    expect(addressSchema.safeParse(VALID).success).toBeTrue();
+  });
+
+  it('elimina els espais laterals abans de validar', () => {
+    expect(addressSchema.safeParse(`  ${VALID}  `).success).toBeTrue();
+  });
+
+  it('falla quan l\'adreça té menys de 58 caràcters → address.invalid', () => {
+    const result = addressSchema.safeParse(SHORT);
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('address.invalid');
+  });
+
+  it('falla amb un caràcter invàlid (dígit 1) → address.invalid', () => {
+    const result = addressSchema.safeParse(INVALID_CHAR);
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('address.invalid');
+  });
+
+  it('falla amb lletres minúscules → address.invalid', () => {
+    const result = addressSchema.safeParse('a'.repeat(58));
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('address.invalid');
+  });
+
+  it('falla amb una cadena buida → address.invalid', () => {
+    const result = addressSchema.safeParse('');
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('address.invalid');
+  });
+});
+
+describe('isAddress', () => {
+  it('retorna true per a una adreça vàlida', () => {
+    expect(isAddress(VALID)).toBeTrue();
+  });
+
+  it('retorna true quan l\'adreça té espais laterals (elimina els espais)', () => {
+    expect(isAddress(`  ${VALID}  `)).toBeTrue();
+  });
+
+  it('retorna false per a una adreça de menys de 58 caràcters', () => {
+    expect(isAddress(SHORT)).toBeFalse();
+  });
+
+  it('retorna false per a un caràcter invàlid', () => {
+    expect(isAddress(INVALID_CHAR)).toBeFalse();
+  });
+
+  it('retorna false per a una cadena buida', () => {
+    expect(isAddress('')).toBeFalse();
+  });
+
+  it('retorna false per a lletres minúscules', () => {
+    expect(isAddress('a'.repeat(58))).toBeFalse();
+  });
+});
+
+describe('parseAddressList', () => {
+  const A = asAddress(VALID);
+  const B = asAddress(B_ADDR);
+  const C = asAddress(C_ADDR);
+
+  it('retorna arrays buits per a una cadena buida', () => {
+    expect(parseAddressList('')).toEqual({ valid: [], invalid: [] });
+  });
+
+  it('retorna arrays buits per a una cadena d\'espais', () => {
+    expect(parseAddressList('   \n  \r\n  ')).toEqual({ valid: [], invalid: [] });
+  });
+
+  it('analitza una sola adreça vàlida', () => {
+    const result = parseAddressList(A);
+    expect(result.valid).toEqual([A]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('analitza múltiples adreces separades per salts de línia', () => {
+    const result = parseAddressList(`${A}\n${B}`);
+    expect(result.valid).toEqual([A, B]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('analitza múltiples adreces separades per \\r\\n', () => {
+    const result = parseAddressList(`${A}\r\n${B}`);
+    expect(result.valid).toEqual([A, B]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('agafa la primera columna d\'una línia CSV (separada per comes)', () => {
+    const result = parseAddressList(`${A},etiqueta,extra`);
+    expect(result.valid).toEqual([A]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('agafa la primera columna separada per punt i coma', () => {
+    const result = parseAddressList(`${A};etiqueta`);
+    expect(result.valid).toEqual([A]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('agafa la primera columna separada per tabuladors', () => {
+    const result = parseAddressList(`${A}\tetiqueta`);
+    expect(result.valid).toEqual([A]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('deduplica les adreces vàlides repetides', () => {
+    const result = parseAddressList(`${A}\n${A}\n${A}`);
+    expect(result.valid).toEqual([A]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('no deduplica les adreces invàlides', () => {
+    const result = parseAddressList('invalida\ninvalida');
+    expect(result.invalid).toEqual(['invalida', 'invalida']);
+  });
+
+  it('posa les adreces invàlides a la llista d\'invàlides', () => {
+    const result = parseAddressList('noesunaadreça');
+    expect(result.valid).toEqual([]);
+    expect(result.invalid).toEqual(['noesunaadreça']);
+  });
+
+  it('gestiona una barreja d\'adreces vàlides i invàlides', () => {
+    const result = parseAddressList(`${A}\ninvalida\n${B}`);
+    expect(result.valid).toEqual([A, B]);
+    expect(result.invalid).toEqual(['invalida']);
+  });
+
+  it('ignora les línies en blanc entre entrades', () => {
+    const result = parseAddressList(`${A}\n\n\n${B}`);
+    expect(result.valid).toEqual([A, B]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('conserva l\'ordre d\'inserció per a les adreces vàlides', () => {
+    const result = parseAddressList(`${C}\n${B}\n${A}`);
+    expect(result.valid).toEqual([C, B, A]);
+  });
+});

--- a/client/src/domain/address.ts
+++ b/client/src/domain/address.ts
@@ -1,0 +1,50 @@
+import * as z from 'zod';
+
+const ALGORAND_ADDR_RE = /^[A-Z2-7]{58}$/;
+
+declare const addressBrand: unique symbol;
+export type Address = string & { readonly [addressBrand]: true };
+
+export const addressSchema = z
+  .string()
+  .trim()
+  .regex(ALGORAND_ADDR_RE, { message: 'address.invalid' })
+  .transform((s): Address => s as Address);
+
+export function isAddress(value: string): value is Address {
+  return ALGORAND_ADDR_RE.test(value.trim());
+}
+
+export function asAddress(value: string): Address {
+  return addressSchema.parse(value);
+}
+
+export function parseAddressList(text: string): { valid: Address[]; invalid: string[] } {
+  const lines = text.split(/[\r\n]+/).filter((l) => l.trim());
+
+  const valid: Address[] = [];
+  const validSet = new Set<string>();
+  const invalid: string[] = [];
+
+  for (const line of lines) {
+    const tokens = line.split(/[,;\t]+/).flatMap((t) => {
+      const trimmed = t.trim();
+      return trimmed ? [trimmed] : [];
+    });
+
+    const addr = tokens[0];
+
+    if (!addr) continue;
+
+    if (isAddress(addr)) {
+      if (!validSet.has(addr)) {
+        valid.push(addr);
+        validSet.add(addr);
+      }
+    } else {
+      invalid.push(addr);
+    }
+  }
+
+  return { valid, invalid };
+}

--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -1,0 +1,3 @@
+export * from './address';
+export * from './organization';
+export * from './organizationDraft';

--- a/client/src/domain/organization.ts
+++ b/client/src/domain/organization.ts
@@ -1,0 +1,25 @@
+import * as z from 'zod';
+import { addressSchema } from './address';
+
+declare const organizationIdBrand: unique symbol;
+export type OrganizationId = number & { readonly [organizationIdBrand]: true };
+
+export const organizationIdSchema = z
+    .number()
+    .int()
+    .nonnegative()
+    .transform((n): OrganizationId => n as OrganizationId);
+
+export function asOrganizationId(n: number): OrganizationId {
+  return organizationIdSchema.parse(n);
+}
+
+const organizationSchema = z.object({
+  id: organizationIdSchema,
+  name: z.string(),
+  description: z.string(),
+  organizer: addressSchema,
+  memberCount: z.number().int().nonnegative(),
+});
+
+export type Organization = z.infer<typeof organizationSchema>;

--- a/client/src/domain/organizationDraft.test.ts
+++ b/client/src/domain/organizationDraft.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'bun:test';
+import { organizationDraftSchema } from './organizationDraft';
+
+function errorMessages(result: { success: boolean; error?: { issues: { message: string }[] } }): string[] {
+  if (result.success || !result.error) return [];
+  return result.error.issues.map((i) => i.message);
+}
+
+describe('organizationDraftSchema', () => {
+  it('passa amb un nom i una descripció vàlids', () => {
+    const result = organizationDraftSchema.safeParse({ name: 'La meva org', description: 'Una descripció' });
+    expect(result.success).toBeTrue();
+  });
+
+  it('elimina els espais laterals del nom i la descripció', () => {
+    const result = organizationDraftSchema.safeParse({ name: '  La meva org  ', description: '  Desc  ' });
+    expect(result.success).toBeTrue();
+  });
+
+  it('falla amb un nom buit → org.empty-name', () => {
+    const result = organizationDraftSchema.safeParse({ name: '', description: 'Desc' });
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('org.empty-name');
+  });
+
+  it('falla amb un nom d\'espais → org.empty-name', () => {
+    const result = organizationDraftSchema.safeParse({ name: '   ', description: 'Desc' });
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('org.empty-name');
+  });
+
+  it('falla amb una descripció buida → org.empty-description', () => {
+    const result = organizationDraftSchema.safeParse({ name: 'La meva org', description: '' });
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('org.empty-description');
+  });
+
+  it('falla amb una descripció d\'espais → org.empty-description', () => {
+    const result = organizationDraftSchema.safeParse({ name: 'La meva org', description: '  ' });
+    expect(result.success).toBeFalse();
+    expect(errorMessages(result)).toContain('org.empty-description');
+  });
+
+  it('informa dels dos errors quan tant el nom com la descripció són buits', () => {
+    const result = organizationDraftSchema.safeParse({ name: '', description: '' });
+    expect(result.success).toBeFalse();
+    const codes = errorMessages(result);
+    expect(codes).toContain('org.empty-name');
+    expect(codes).toContain('org.empty-description');
+  });
+});

--- a/client/src/domain/organizationDraft.ts
+++ b/client/src/domain/organizationDraft.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod';
+
+export const organizationDraftSchema = z.object({
+  name: z.string().trim().min(1, { message: 'org.empty-name' }),
+  description: z.string().trim().min(1, { message: 'org.empty-description' }),
+});
+
+export type OrganizationDraft = z.infer<typeof organizationDraftSchema>;


### PR DESCRIPTION
  ## Descripció del canvi

Afegeix els tipus de domini i *schemas* de validació per a organitzacions: el tipus de domini `Organization` amb el seu `OrganizationId` *branded*, el tipus `OrganizationDraft` per a formularis, i el tipus `Address` amb validació d'adreces Algorand. Inclou també el tipus *wire* `OnChainOrganization` i el *mapper* corresponent per transformar dades ARC-56 al model de domini.

  ## Tipus de canvi

  - [x] `feat` — Nova funcionalitat
  - [ ] `fix` — Correcció d'error
  - [ ] `docs` — Documentació
  - [ ] `refactor` — Refactorització (no canvia funcionalitat)
  - [ ] `test` — Tests
  - [ ] `chore` — Manteniment, deps, CI

  ## Issues relacionades

  Closes #400

  ## Llista de verificació

  - [x] He revisat el meu propi codi
  - [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
  - [x] He executat `make lint` i passa sense errors
  - [x] La documentació s'ha actualitzat si cal