### PR TITLE
feat(client): llistat i consulta d'organitzacions

### DIFF
--- a/client/src/algorand/organizations.ts
+++ b/client/src/algorand/organizations.ts
@@ -1,5 +1,6 @@
 import algosdk from 'algosdk';
 
+import type {OnChainOrganization} from "@/algorand/wire";
 import {algodClient, APP_ID} from './config';
 
 import {
@@ -14,6 +15,7 @@ import {
     CENSUS_BOX_MBR,
     CENSUS_BATCH,
     type TransactionSigner,
+    bytesEqual,
 } from './_contract';
 
 export async function createOrganization(
@@ -71,6 +73,36 @@ export async function createOrganization(
     }
 }
 
+export async function getOrganization(orgId: number): Promise<OnChainOrganization | null> {
+    try {
+        const box = await algodClient.getApplicationBoxByName(APP_ID, orgBoxKey(orgId)).do();
+        return decodeOrganization(box.value);
+    } catch {
+        return null;
+    }
+}
+
+export async function getAllOrganizationIds(): Promise<number[]> {
+    try {
+        const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
+        const orgPrefix = enc.encode('org_'); // 4 bytes
+        const ids: number[] = [];
+
+        for (const box of boxes) {
+            const name = box.name;
+            // org_ box names: "org_" (4) + uint64 (8) = 12 bytes
+            if (name.length === 12 && bytesEqual(name.slice(0, 4), orgPrefix)) {
+                const id = Number(algosdk.bytesToBigInt(name.slice(4)));
+                if (id > 0) ids.push(id);
+            }
+        }
+
+        return ids.sort((a, b) => a - b);
+    } catch {
+        return [];
+    }
+}
+
 export async function addToCensus(
     signer: TransactionSigner,
     sender: string,
@@ -125,4 +157,58 @@ export async function addToCensus(
     } catch (err) {
         throw decodeContractError(err);
     }
+}
+
+export async function getCensusMembers(orgId: number): Promise<string[]> {
+    try {
+        const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
+        const prefix = enc.encode('cs_'); // 3 bytes
+        const orgIdBytes = algosdk.bigIntToBytes(orgId, 8);
+        const members: string[] = [];
+
+        for (const box of boxes) {
+            const name = box.name;
+            // census box names: "cs_" (3) + org_id (8) + member pubkey (32) = 43 bytes
+            if (
+                name.length === 43 &&
+                bytesEqual(name.slice(0, 3), prefix) &&
+                bytesEqual(name.slice(3, 11), orgIdBytes)
+            ) {
+                members.push(algosdk.encodeAddress(name.slice(11)));
+            }
+        }
+
+        return members;
+    } catch {
+        return [];
+    }
+}
+
+export async function getCensusMemberCount(orgId: number): Promise<number> {
+    try {
+        const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do();
+        const prefix = enc.encode('cs_');
+        const orgIdBytes = algosdk.bigIntToBytes(orgId, 8);
+        return boxes.filter(
+            (box) =>
+                box.name.length === 43 &&
+                bytesEqual(box.name.slice(0, 3), prefix) &&
+                bytesEqual(box.name.slice(3, 11), orgIdBytes),
+        ).length;
+    } catch {
+        return 0;
+    }
+}
+
+function decodeOrganization(data: Uint8Array): OnChainOrganization {
+    const type = algosdk.ABIType.from('(uint64,string,string,address)');
+    const decoded = type.decode(data) as [bigint, string, string, string];
+
+    return {
+        orgId: Number(decoded[0]),
+        name: decoded[1],
+        description: decoded[2],
+        organizer: decoded[3],
+        memberCount: 0,
+    };
 }

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -1,0 +1,48 @@
+import {queryOptions} from '@tanstack/react-query';
+import {
+    getOrganization,
+    getAllOrganizationIds,
+    getCensusMembers,
+    getCensusMemberCount
+} from './organizations';
+
+import {mapToOrganization} from './mappers';
+import type {Organization} from '@/domain';
+
+import {queryKeys} from './queryKeys';
+
+// ── Fetchers asíncrons ────────────────────────────────────────────────────
+
+async function fetchOrganization(id: number): Promise<Organization | null> {
+    const onChain = await getOrganization(id);
+    if (!onChain) return null;
+    const memberCount = await getCensusMemberCount(id);
+    return mapToOrganization(id, onChain, memberCount);
+}
+
+async function fetchOrganizations(): Promise<Organization[]> {
+    const ids = await getAllOrganizationIds();
+    const results = await Promise.all(ids.map(fetchOrganization));
+    return results.filter((o): o is Organization => o !== null);
+}
+
+async function fetchCensusMembers(orgId: number): Promise<string[]> {
+    return getCensusMembers(orgId);
+}
+
+// ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
+
+export const organizationQueries = {
+    all: () => queryOptions({
+        queryKey: queryKeys.organizations.all(),
+        queryFn: fetchOrganizations,
+    }),
+    detail: (id: number) => queryOptions({
+        queryKey: queryKeys.organizations.detail(id),
+        queryFn: () => fetchOrganization(id),
+    }),
+    census: (id: number) => queryOptions({
+        queryKey: queryKeys.organizations.census(id),
+        queryFn: () => fetchCensusMembers(id),
+    })
+};

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -1,7 +1,8 @@
 export const queryKeys = {
     organizations: {
         all: () => ['organizations'] as const,
-        detail: (id: number) => ['organizations', id] as const
+        detail: (id: number) => ['organizations', id] as const,
+        census: (id: number) => ['organizations', id, 'census'] as const
     },
     // Prefix keys for broad namespace invalidation in mutations
     censusPrefix: ['census'] as const,

--- a/client/src/components/RouteError.tsx
+++ b/client/src/components/RouteError.tsx
@@ -1,0 +1,28 @@
+import {useRouteError, isRouteErrorResponse, useNavigate} from 'react-router-dom';
+import {useTranslation} from 'react-i18next';
+import {AlertCircle, ArrowLeft} from 'lucide-react';
+
+export function RouteError() {
+    const error = useRouteError();
+    const {t} = useTranslation();
+    const navigate = useNavigate();
+
+    const message = isRouteErrorResponse(error)
+        ? error.statusText
+        : error instanceof Error
+            ? error.message
+            : t('errors.unknown');
+
+    return (
+        <div className="mx-auto flex max-w-md flex-col items-center gap-6 px-6 py-20 text-center">
+            <AlertCircle size={40} className="text-muted"/>
+            <p className="text-sm text-muted">{message}</p>
+            <button
+                onClick={() => navigate(-1)}
+                className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm text-muted transition hover:text-fg"
+            >
+                <ArrowLeft size={14}/> {t('common.back')}
+            </button>
+        </div>
+    );
+}

--- a/client/src/components/organization/OrganizationHero.tsx
+++ b/client/src/components/organization/OrganizationHero.tsx
@@ -1,0 +1,108 @@
+import {useTranslation} from 'react-i18next';
+import {Crown} from 'lucide-react';
+
+import {Badge} from '@/components/ui/Badge';
+
+interface Stat {
+    label: string;
+    value: number | string;
+    accent?: boolean;
+}
+
+interface Props {
+    name: string;
+    description: string;
+    isOrganizer: boolean;
+    isMember: boolean;
+    stats: Stat[];
+}
+
+function initials(name: string): string {
+    const parts = name.trim().split(/[\s-]+/).filter(Boolean);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function OrganizationHero({name, description, isOrganizer, isMember, stats}: Props) {
+    const {t} = useTranslation();
+
+    return (
+        <div className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-surface via-surface/95 to-elevated/60 p-6 shadow-xl backdrop-blur-sm sm:p-8">
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -right-24 -top-24 size-64 rounded-full bg-gradient-to-br from-primary/25 via-accent/15 to-transparent blur-3xl"
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -left-32 bottom-0 size-56 rounded-full bg-gradient-to-tr from-accent/15 to-transparent blur-3xl"
+            />
+
+            <div className="relative flex flex-col gap-6 sm:flex-row sm:items-start">
+                <div className="flex shrink-0 items-center gap-4 sm:flex-col sm:items-start">
+                    <div
+                        aria-hidden
+                        className="flex size-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent font-display text-xl font-bold text-primary-fg shadow-glow"
+                    >
+                        {initials(name)}
+                    </div>
+                </div>
+
+                <div className="min-w-0 flex-1">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                        {isOrganizer ? (
+                            <Badge tone="warning">
+                                <Crown size={11}/> {t('common.organizer')}
+                            </Badge>
+                        ) : isMember ? (
+                            <Badge tone="success">{t('common.member')}</Badge>
+                        ) : (
+                            <Badge tone="neutral">{t('org.not-member-short')}</Badge>
+                        )}
+                    </div>
+
+                    <h1 className="font-display text-3xl font-semibold tracking-tight text-fg sm:text-4xl lg:text-5xl">
+                        {name}
+                    </h1>
+
+                    {description && (
+                        <div className="relative mt-5 max-w-3xl">
+                            <div
+                                aria-hidden
+                                className="absolute -inset-y-2 -left-3 -right-6 rounded-2xl bg-gradient-to-r from-primary/[0.06] via-accent/[0.03] to-transparent"
+                            />
+                            <div className="relative py-1 pl-6">
+                                <span
+                                    aria-hidden
+                                    className="absolute inset-y-1 left-0 w-1 rounded-full bg-gradient-to-b from-primary via-accent to-primary/30"
+                                />
+                                <span
+                                    aria-hidden
+                                    className="absolute inset-y-1 left-0 w-1 rounded-full bg-gradient-to-b from-primary to-accent opacity-60 blur-md"
+                                />
+                                <p className="text-base leading-relaxed text-fg/85 sm:text-[17px] sm:leading-[1.8]">
+                                    {description}
+                                </p>
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-border/60 pt-5">
+                        {stats.map(s => (
+                            <div key={s.label} className="flex items-baseline gap-2">
+                                <span
+                                    className={`font-display text-2xl font-bold tabular-nums ${
+                                        s.accent ? 'bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent' : 'text-fg'
+                                    }`}
+                                >
+                                    {s.value}
+                                </span>
+                                <span className="text-xs uppercase tracking-wide text-muted">{s.label}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/client/src/components/ui/Badge.tsx
+++ b/client/src/components/ui/Badge.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes } from 'react';
+
+type Tone = 'neutral' | 'primary' | 'success' | 'warning' | 'danger';
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+  tone?: Tone;
+}
+
+const tones: Record<Tone, string> = {
+  neutral: 'bg-surface text-muted border-border',
+  primary: 'bg-primary/10 text-primary border-primary/30',
+  success: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/30',
+  warning: 'bg-amber-500/10 text-amber-500 border-amber-500/30',
+  danger: 'bg-rose-500/10 text-rose-500 border-rose-500/30',
+};
+
+export function Badge({ tone = 'neutral', className = '', ...rest }: Props) {
+  return (
+    <span
+      {...rest}
+      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium ${tones[tone]} ${className}`}
+    />
+  );
+}

--- a/client/src/components/ui/Tabs.tsx
+++ b/client/src/components/ui/Tabs.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react';
+
+interface TabsProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Tabs({ children, className = '' }: TabsProps) {
+  return <div className={className}>{children}</div>;
+}
+
+interface TabListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabList({ children, className = '' }: TabListProps) {
+  return (
+    <div
+      role="tablist"
+      className={`flex gap-1 overflow-x-auto border-b border-border ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface TabProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  count?: number;
+}
+
+export function Tab({ active, onClick, label, count }: TabProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`relative inline-flex h-11 shrink-0 items-center gap-2 px-5 text-sm font-medium transition ${
+        active ? 'text-fg' : 'text-muted hover:text-fg'
+      }`}
+    >
+      <span>{label}</span>
+      {typeof count === 'number' && (
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-semibold tabular-nums transition ${
+            active
+              ? 'bg-primary/15 text-primary'
+              : 'bg-elevated text-muted'
+          }`}
+        >
+          {count}
+        </span>
+      )}
+      {active && (
+        <span className="absolute inset-x-3 -bottom-px h-0.5 rounded-full bg-gradient-to-r from-primary to-accent" />
+      )}
+    </button>
+  );
+}
+
+interface TabPanelProps {
+  active: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabPanel({ active, children, className = '' }: TabPanelProps) {
+  if (!active) return null;
+  return (
+    <div role="tabpanel" className={className}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/domain/census.ts
+++ b/client/src/domain/census.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod';
+import { addressSchema } from './address';
+import { organizationIdSchema } from './organization';
+
+const censusSchema = z.object({
+  orgId: organizationIdSchema,
+  members: z.array(addressSchema),
+});
+
+type Census = z.infer<typeof censusSchema>;

--- a/client/src/hooks/utils.test.ts
+++ b/client/src/hooks/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test';
+import { parseRouteId } from './utils';
+
+describe('parseRouteId', () => {
+  it('llança error quan l\'entrada és undefined', () => {
+    expect(() => parseRouteId(undefined)).toThrowError();
+  });
+
+  it('llança error quan l\'entrada és null', () => {
+    expect(() => parseRouteId(null)).toThrowError();
+  });
+
+  it('analitza una cadena numèrica vàlida', () => {
+    expect(parseRouteId('123')).toBe(123);
+  });
+
+  it('llança un error quan l\'id és zero', () => {
+    expect(() => parseRouteId('0')).toThrowError();
+  });
+
+  it('llança un error quan és una cadena no numèrica', () => {
+    expect(() => parseRouteId('abc')).toThrowError();
+  });
+
+  it('llança un error quan és una cadena buida', () => {
+    expect(() => parseRouteId('')).toThrowError();
+  });
+
+  it('trunca la part decimal (comportament de parseInt)', () => {
+    expect(parseRouteId('12.5')).toBe(12);
+  });
+
+  it('llança un error quan és un nombre negatiu', () => {
+    expect(() => parseRouteId('-5')).toThrowError();
+  });
+
+  it('llança un error quan és una cadena que comença amb lletres', () => {
+    expect(() => parseRouteId('abc123')).toThrowError();
+  });
+});

--- a/client/src/hooks/utils.ts
+++ b/client/src/hooks/utils.ts
@@ -1,0 +1,15 @@
+export function parseRouteId(id: unknown): number {
+  if (id === undefined || id === null)
+    throw new Error('ID invàlid')
+
+  if (typeof id === 'string') {
+    const parsedId = parseInt(id, 10)
+
+    if (isNaN(parsedId) || parsedId < 1)
+      throw new Error("ID invàlid")
+
+    return parsedId
+  }
+
+  throw new Error("ID invàlid")
+}

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -9,17 +9,28 @@
   "common": {
     "title": "Títol",
     "cancel": "Cancel·la",
+    "back": "Enrere",
     "previous": "Anterior",
     "next": "Següent",
     "waiting": "Esperant...",
     "description": "Descripció",
     "census": "Cens",
     "addresses": "Adreces",
-    "active": "Activa",
+    "active_one": "Activa",
+    "active_other": "Actives",
     "no-matches": "Cap coincidència",
     "connect": "Connectar",
     "disconnect": "Desconnectar",
-    "step": "Pas {{current}} de {{total}}"
+    "step": "Pas {{current}} de {{total}}",
+    "proposals": "Propostes",
+    "member": "Membre",
+    "members": "Membres",
+    "organizer": "Organitzador",
+    "hide": "Amagar",
+    "add": "Afegir",
+    "remove": "Eliminar",
+    "replace-all": "Substituir tot",
+    "progress": "Processant {{done}} / {{total}}"
   },
   "theme": {
     "toggle": "Canvia el tema",
@@ -100,11 +111,35 @@
     }
   },
   "org": {
+    "title": "Organitzacions",
+    "subtitle": "Organismes de govern als quals pertanys o que gestiones.",
     "valid-addresses": "{{count}} adreces vàlides",
     "census-hint": "Afegeix els membres inicials d'aquesta organització. Podràs modificar el cens més endavant.",
     "submit": "Crea l'organització",
     "new": "Crea una organització",
-    "members": "{{count}} membre",
+    "empty": "Encara no hi ha organitzacions.",
+    "members": "{{count}} membres",
+    "not-found": "Organització no trobada.",
+    "not-member": "No ets membre d'aquesta organització",
+    "not-member-short": "No membre",
+    "show-all-members": "Veure tots els {{count}} membres",
+    "census": {
+      "manage": "Gestiona el cens",
+      "manage-hint": "Modifica els membres de «{{name}}».",
+      "empty": "Encara no hi ha membres.",
+      "empty-search": "Cap adreça coincideix amb la cerca.",
+      "search-placeholder": "Cerca una adreça…",
+      "match-of": "{{shown}} de {{total}}",
+      "added": "{{count}} adreces afegides",
+      "add": "Afegeix {{count}} adreces",
+      "removed": "{{count}} adreces eliminades",
+      "replaced": "Cens substituït per {{count}} adreces",
+      "replace": "Substitueix per {{count}} adreces",
+      "remove-hint": "Selecciona les adreces que vols eliminar del cens.",
+      "selected-count_one": "{{count}} seleccionada",
+      "selected-count_other": "{{count}} seleccionades",
+      "remove-selected": "Elimina {{count}} seleccionades"
+    },
     "dev-addresses": {
       "load": "Carrega adreces dev",
       "hint": "Carrega les adreces declarades a dev-accounts.json"
@@ -129,15 +164,21 @@
       "title": "Organització creada!",
       "text": "\"{{name}}\" ha estat registrada.",
       "cta": "Veure les organitzacions"
+    },
+    "replace-confirm": {
+      "title": "Substituir tot el cens?",
+      "text": "Això substituirà els {{current}} membres actuals de \"{{name}}\" per {{next}} noves adreces. Aquesta acció no es pot desfer."
     }
   },
   "wallet": {
     "connect": "Connecta el wallet per enviar",
     "choose": "Estria wallet",
     "switch": "Canviar de compte",
-    "address-filter-placeholder": "Filtrar per adreça…"
+    "address-filter-placeholder": "Filtrar per adreça…",
+    "waiting-signature": "Esperant signatura…"
   },
   "errors": {
+    "unknown": "Error desconegut",
     "proposal": {
       "empty-title": "El títol no pot estar buit",
       "empty-description": "La descripció no pot estar buida",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -9,17 +9,28 @@
   "common": {
     "title": "Title",
     "cancel": "Cancel",
+    "back": "Back",
     "previous": "Previous",
     "next": "Next",
     "waiting": "Waiting...",
     "description": "Description",
     "census": "Census",
     "addresses": "Addresses",
-    "active": "Active",
+    "active_one": "Active",
+    "active_other": "Active",
     "no-matches": "No matches",
     "connect": "Connect",
     "disconnect": "Disconnect",
-    "step": "Step {{current}} of {{total}}"
+    "step": "Step {{current}} of {{total}}",
+    "proposals": "Proposals",
+    "member": "Member",
+    "members": "Members",
+    "organizer": "Organizer",
+    "hide": "Hide",
+    "add": "Add",
+    "remove": "Remove",
+    "replace-all": "Replace all",
+    "progress": "Processing {{done}} / {{total}}"
   },
   "theme": {
     "toggle": "Toggle theme",
@@ -100,11 +111,35 @@
     }
   },
   "org": {
+    "title": "Organizations",
+    "subtitle": "Governance bodies you belong to, or that you manage.",
     "valid-addresses": "{{count}} valid addresses",
     "census-hint": "Add the initial members of this organization. You can modify the census later.",
     "submit": "Create organization",
     "new": "Create organization",
-    "members": "{{count}} member",
+    "empty": "No organizations yet.",
+    "members": "{{count}} members",
+    "not-found": "Organization not found.",
+    "not-member": "You are not a member of this organization",
+    "not-member-short": "Non-member",
+    "show-all-members": "See all {{count}} members",
+    "census": {
+      "manage": "Manage census",
+      "manage-hint": "Modify the members of \"{{name}}\".",
+      "empty": "There are no members yet.",
+      "empty-search": "No address matches the search.",
+      "search-placeholder": "Search an address…",
+      "match-of": "{{shown}} of {{total}}",
+      "added": "{{count}} addresses added",
+      "add": "Add {{count}} addresses",
+      "removed": "{{count}} addresses removed",
+      "replaced": "Census replaced with {{count}} addresses",
+      "replace": "Replace with {{count}} addresses",
+      "remove-hint": "Select addresses to remove from the census.",
+      "selected-count_one": "{{count}} selected",
+      "selected-count_other": "{{count}} selected",
+      "remove-selected": "Remove {{count}} selected"
+    },
     "dev-addresses": {
       "load": "Load dev addresses",
       "hint": "Load the addresses declared to dev-accounts.json"
@@ -129,15 +164,21 @@
       "title": "Organization created!",
       "text": "\"{{name}}\" has been registered.",
       "cta": "View organizations"
+    },
+    "replace-confirm": {
+      "title": "Replace the entire census?",
+      "text": "This will replace {{current}} current members of \"{{name}}\" with {{next}} new addresses. This action cannot be undone."
     }
   },
   "wallet": {
     "connect": "Connect the wallet to send",
     "choose": "Choose wallet",
     "switch": "Switch account",
-    "address-filter-placeholder": "Filter by address…"
+    "address-filter-placeholder": "Filter by address…",
+    "waiting-signature": "Waiting signature…"
   },
   "errors": {
+    "unknown": "Unknown error",
     "proposal": {
       "empty-title": "Title cannot be empty",
       "empty-description": "Description cannot be empty",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -9,17 +9,28 @@
   "common": {
     "title": "Título",
     "cancel": "Cancelar",
+    "back": "Atrás",
     "previous": "Anterior",
     "next": "Siguiente",
     "waiting": "Esperando...",
     "description": "Descripción",
     "census": "Censo",
     "addresses": "Direcciones",
-    "active": "Activa",
+    "active_one": "Activa",
+    "active_other": "Activas",
     "no-matches": "Ningún resultado",
     "connect": "Conectar",
     "disconnect": "Desconectar",
-    "step": "Paso {{current}} de {{total}}"
+    "step": "Paso {{current}} de {{total}}",
+    "proposals": "Propuestas",
+    "member": "Miembro",
+    "members": "Miembros",
+    "organizer": "Organizador",
+    "hide": "Ocultar",
+    "add": "Añadir",
+    "remove": "Eliminar",
+    "replace-all": "Remplazar todo",
+    "progress": "Procesando {{done}} / {{total}}"
   },
   "theme": {
     "toggle": "Cambiar tema",
@@ -100,11 +111,35 @@
     }
   },
   "org": {
+    "title": "Organizaciones",
+    "subtitle": "Organismos de gobernanza a los que perteneces o que gestionas.",
     "valid-addresses": "{{count}} direcciones válidas",
     "census-hint": "Añade los miembros iniciales de esta organización. Podrás modificar el censo más adelante.",
     "submit": "Crea la organización",
     "new": "Crea una organización",
-    "members": "{{count}} miembro",
+    "empty": "Todavía no hay organizaciones.",
+    "members": "{{count}} miembros",
+    "not-found": "Organización no encontrada.",
+    "not-member": "No eres miembro de esta organización",
+    "not-member-short": "No miembro",
+    "show-all-members": "Ver todos los {{count}} miembros",
+    "census": {
+      "manage": "Gestionar censo",
+      "manage-hint": "Modifica los miembros de «{{name}}».",
+      "empty": "Todavía no hay miembros.",
+      "empty-search": "Ninguna dirección coincide con la búsqueda.",
+      "search-placeholder": "Busca una dirección…",
+      "match-of": "{{shown}} de {{total}}",
+      "added": "{{count}} direcciones añadidas",
+      "add": "Añade {{count}} direcciones",
+      "removed": "{{count}} direcciones eliminadas",
+      "replaced": "Censo reemplazado con {{count}} direcciones",
+      "replace": "Sustituye por {{count}} direcciones",
+      "remove-hint": "Selecciona las direcciones que quieres eliminar del censo.",
+      "selected-count_one": "{{count}} seleccionada",
+      "selected-count_other": "{{count}} seleccionadas",
+      "remove-selected": "Eliminar {{count}} seleccionadas"
+    },
     "dev-addresses": {
       "load": "Carga direcciones dev",
       "hint": "Carga las direcciones declaradas en dev-accounts.json"
@@ -129,15 +164,21 @@
       "title": "Organización creada!",
       "text": "\"{{name}}\" ha sido registrada.",
       "cta": "Ver las organizaciones"
+    },
+    "replace-confirm": {
+      "title": "¿Reemplazar todo el censo?",
+      "text": "Esto reemplazará a los {{count}} miembros actuales de \"{{name}}\" por {{next}} nuevas direcciones. Esta acción no puede deshacerse."
     }
   },
   "wallet": {
     "connect": "Conecta la wallet para enviar",
     "choose": "Escoger wallet",
     "switch": "Cambiar de cuenta",
-    "address-filter-placeholder": "Filtrar por dirección…"
+    "address-filter-placeholder": "Filtrar por dirección…",
+    "waiting-signature": "Esperando firma…"
   },
   "errors": {
+    "unknown": "Error desconocido",
     "proposal": {
       "empty-title": "El título no puede estar vacío",
       "empty-description": "La descripción no puede estar vacía",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,10 +3,14 @@ import React from 'react';
 import {RouterProvider} from 'react-router-dom';
 import {createRoot} from 'react-dom/client';
 
+import {QueryClientProvider} from "@tanstack/react-query";
+
 import {NetworkId, WalletId, WalletManager} from "@txnlab/use-wallet-react";
 
 import {bootstrapDevAccountsToKmd} from "@/algorand/dev-accounts.ts";
 import {ThemeProvider} from '@/theme/ThemeProvider';
+
+import {queryClient} from './queryClient'
 import {router} from './router';
 
 import './index.css';
@@ -43,8 +47,10 @@ if (walletManager.activeNetwork === NetworkId.LOCALNET) {
 
 createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <ThemeProvider>
-            <RouterProvider router={router}/>
-        </ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider>
+                <RouterProvider router={router}/>
+            </ThemeProvider>
+        </QueryClientProvider>
     </React.StrictMode>,
 );

--- a/client/src/pages/OrganizationDetailPage.tsx
+++ b/client/src/pages/OrganizationDetailPage.tsx
@@ -1,0 +1,126 @@
+import {useLoaderData, useNavigate} from 'react-router-dom';
+import {useState} from 'react';
+
+import {useTranslation} from 'react-i18next';
+import {ArrowLeft, Lock} from 'lucide-react';
+
+import {useQuery} from '@tanstack/react-query';
+
+import {organizationQueries} from '@/algorand/queries';
+
+import {useAlgorand} from '@/hooks/useAlgorand';
+
+import {OrganizationHero} from '@/components/organization/OrganizationHero';
+import {Tabs, TabList, Tab, TabPanel} from '@/components/ui/Tabs';
+
+type ActiveTab = 'proposals' | 'census';
+
+export function OrganizationDetailPage() {
+    const id = useLoaderData() as number
+
+    const {t} = useTranslation();
+    const navigate = useNavigate();
+    const {address} = useAlgorand();
+
+    const orgQuery = useQuery({
+        ...organizationQueries.detail(id)
+    });
+
+    const censusQuery = useQuery({
+        ...organizationQueries.census(id)
+    });
+
+    const organization = orgQuery.data ?? null;
+    const censusMembers = censusQuery.data ?? [];
+    const orgLoading = orgQuery.isPending;
+
+    const [activeTab, setActiveTab] = useState<ActiveTab>('proposals');
+
+    if (orgLoading) {
+        return (
+            <div className="mx-auto max-w-6xl space-y-6 px-6 py-14">
+                <div className="h-5 w-20 animate-pulse rounded-full bg-surface"/>
+                <div className="h-48 w-full animate-pulse rounded-3xl bg-surface"/>
+                <div className="h-12 w-full animate-pulse rounded-2xl bg-surface"/>
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {['od-a', 'od-b', 'od-c'].map(k => (
+                        <div key={k} className="h-44 animate-pulse rounded-2xl bg-surface"/>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    if (!organization) {
+        return (
+            <div className="mx-auto max-w-4xl px-6 py-20 text-center text-muted">
+                {t('org.not-found')}
+            </div>
+        );
+    }
+
+    const isOrganizer = address === organization.organizer;
+    const isMember = address ? censusMembers.includes(address) : false;
+
+    const stats = [
+        {label: t('commom.members'), value: organization.memberCount, accent: true},
+        {label: t('common.proposals'), value: /*TODO*/-1},
+        {label: t('common.active', {count: 2}), value: /*TODO*/-1},
+    ];
+
+    return (
+        <div className="mx-auto max-w-6xl px-6 py-10 sm:py-14">
+            <button
+                onClick={() => navigate(-1)}
+                className="mb-6 inline-flex items-center gap-2 text-sm text-muted transition hover:text-fg"
+            >
+                <ArrowLeft size={16}/> {t('common.back')}
+            </button>
+
+            <OrganizationHero
+                name={organization.name}
+                description={organization.description}
+                isOrganizer={isOrganizer}
+                isMember={isMember}
+                stats={stats}
+            />
+
+            {!isMember && !isOrganizer && (
+                <div
+                    className="mt-6 flex items-center gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-5 py-4 text-sm text-amber-600 dark:text-amber-400">
+                    <Lock size={16} className="shrink-0"/>
+                    {t('org.not-member')}
+                </div>
+            )}
+
+            <Tabs className="mt-10">
+                <TabList className="mb-8">
+                    <Tab
+                        active={activeTab === 'proposals'}
+                        onClick={() => setActiveTab('proposals')}
+                        label={t('common.proposals')}
+                        count={/*TODO*/-1}
+                    />
+                    <Tab
+                        active={activeTab === 'census'}
+                        onClick={() => setActiveTab('census')}
+                        label={t('common.census')}
+                        count={organization.memberCount}
+                    />
+                </TabList>
+
+                <TabPanel active={activeTab === 'proposals'}>
+                    <>
+                        TODO
+                    </>
+                </TabPanel>
+
+                <TabPanel active={activeTab === 'census'}>
+                    <>
+                        TODO
+                    </>
+                </TabPanel>
+            </Tabs>
+        </div>
+    );
+}

--- a/client/src/pages/OrganizationsPage.tsx
+++ b/client/src/pages/OrganizationsPage.tsx
@@ -1,0 +1,75 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Plus, Users, Crown } from 'lucide-react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/Badge';
+
+import { organizationQueries } from '@/algorand/queries';
+import { useAlgorand } from '@/hooks/useAlgorand';
+
+export function OrganizationsPage() {
+  const { t } = useTranslation();
+  const { data: organizations = [] } = useQuery(organizationQueries.all());
+  const { address } = useAlgorand();
+
+  return (
+    <div className="mx-auto max-w-7xl px-6 py-14">
+      <div className="mb-10 flex flex-wrap items-end justify-between gap-6">
+        <div>
+          <h1 className="font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+            {t('org.title')}
+          </h1>
+          <p className="mt-2 text-muted">{t('org.subtitle')}</p>
+        </div>
+        <Link
+          to="/organizations/new"
+          className="inline-flex h-11 items-center gap-2 rounded-full bg-gradient-to-br from-primary to-accent px-5 text-sm font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+        >
+          <Plus size={16} />
+          {t('org.new')}
+        </Link>
+      </div>
+
+      {organizations.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border p-12 text-center text-muted">
+          {t('org.empty')}
+        </div>
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {organizations.map(org => {
+            const isOrganizer = address === org.organizer;
+
+            return (
+              <Link
+                key={org.id}
+                to={`/organizations/${org.id}`}
+                className="group flex flex-col rounded-2xl border border-border/70 bg-surface/80 p-6 transition hover:-translate-y-0.5 hover:border-primary/60 hover:shadow-glow"
+              >
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  {isOrganizer && (
+                    <Badge tone="warning">
+                      <Crown size={11} />
+                      {t('common.organizer')}
+                    </Badge>
+                  )}
+                </div>
+
+                <h3 className="font-display text-lg font-semibold text-fg group-hover:text-primary">
+                  {org.name}
+                </h3>
+                <p className="mt-1.5 line-clamp-2 text-sm text-muted">{org.description}</p>
+
+                <div className="mt-5 flex items-center gap-1.5 text-xs text-muted">
+                  <Users size={13} />
+                  {t('org.members', { count: org.memberCount })}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/queryClient.ts
+++ b/client/src/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 15_000,
+      retry: 1,
+    },
+  },
+});

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,14 +1,55 @@
 import {createBrowserRouter} from 'react-router-dom';
 
+import {queryClient} from "@/queryClient.ts";
+import {organizationQueries} from "@/algorand/queries";
+
+import {RouteError} from "@/components/RouteError";
+
 import App from './App';
 
 import {LandingPage} from '@/pages/LandingPage';
+
+import {OrganizationsPage} from "@/pages/OrganizationsPage";
 import {NewOrganizationPage} from "@/pages/NewOrganizationPage";
+import {OrganizationDetailPage} from "@/pages/OrganizationDetailPage";
+
+import {parseRouteId} from "@/hooks/utils.ts";
 
 export const router = createBrowserRouter([{
     element: <App/>,
     children: [
-        {path: '/', element: <LandingPage/>},
-        {path: '/organizations/new', element: <NewOrganizationPage/>},
+        {
+            path: '/',
+            element: <LandingPage/>
+        },
+        {
+            path: '/organizations',
+            loader: async () => {
+                await queryClient.ensureQueryData(organizationQueries.all())
+
+                return null;
+            },
+            element: <OrganizationsPage/>,
+            errorElement: <RouteError/>,
+        },
+        {
+            path: '/organizations/:id',
+            loader: async ({params}) => {
+                const id = parseRouteId(params.id);
+
+                await Promise.all([
+                    queryClient.ensureQueryData(organizationQueries.detail(id)),
+                    queryClient.ensureQueryData(organizationQueries.census(id))
+                ]);
+
+                return id;
+            },
+            element: <OrganizationDetailPage/>,
+            errorElement: <RouteError/>,
+        },
+        {
+            path: '/organizations/new',
+            element: <NewOrganizationPage/>
+        },
     ],
 }]);


### PR DESCRIPTION
## Descripció del canvi

Implementa la pàgina de llistat d'organitzacions i la pàgina de detall amb el seu cens, llegint les dades directament del contracte intel·ligent d'Algorand.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #399

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal