### PR TITLE
feat(client): wizard de creació de propostes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^0.400.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-day-picker": "^10.0.0",
     "react-hook-form": "^7.75.0",
     "react-i18next": "^14.1.2",
     "react-router-dom": "^6.24.0",

--- a/client/src/algorand/organizations.ts
+++ b/client/src/algorand/organizations.ts
@@ -17,6 +17,7 @@ import {
     CENSUS_BATCH,
     type TransactionSigner,
     bytesEqual,
+    singleBoxExists,
 } from './_contract';
 
 export async function createOrganization(
@@ -233,6 +234,10 @@ export async function getCensusMemberCount(orgId: number): Promise<number> {
     } catch {
         return 0;
     }
+}
+
+export async function isInCensusChain(address: string, orgId: number): Promise<boolean> {
+    return singleBoxExists(censusBoxKey(orgId, address));
 }
 
 function decodeOrganization(data: Uint8Array): OnChainOrganization {

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -3,12 +3,13 @@ import {
     getOrganization,
     getAllOrganizationIds,
     getCensusMembers,
-    getCensusMemberCount
+    getCensusMemberCount,
+    isInCensusChain
 } from './organizations';
 
-import {mapToOrganization} from './mappers';
 import type {Organization} from '@/domain';
 
+import {mapToOrganization} from './mappers';
 import {queryKeys} from './queryKeys';
 
 // ── Fetchers asíncrons ────────────────────────────────────────────────────
@@ -30,6 +31,20 @@ async function fetchCensusMembers(orgId: number): Promise<string[]> {
     return getCensusMembers(orgId);
 }
 
+async function fetchUserOrganizations(address: string): Promise<Organization[]> {
+    const ids = await getAllOrganizationIds();
+
+    const results = await Promise.all(
+        ids.map(async (id) => {
+            const isMember = await isInCensusChain(address, id);
+            if (!isMember) return null;
+            return fetchOrganization(id);
+        }),
+    );
+
+    return results.filter((o): o is Organization => o !== null);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -44,5 +59,9 @@ export const organizationQueries = {
     census: (id: number) => queryOptions({
         queryKey: queryKeys.organizations.census(id),
         queryFn: () => fetchCensusMembers(id),
-    })
+    }),
+    forUser: (address: string) => queryOptions({
+        queryKey: queryKeys.organizations.forUser(address),
+        queryFn: () => fetchUserOrganizations(address),
+    }),
 };

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -2,8 +2,12 @@ export const queryKeys = {
     organizations: {
         all: () => ['organizations'] as const,
         detail: (id: number) => ['organizations', id] as const,
-        census: (id: number) => ['organizations', id, 'census'] as const
+        census: (id: number) => ['organizations', id, 'census'] as const,
+        forUser: (address: string) => ['organizations', 'user', address] as const,
     },
     // Prefix keys for broad namespace invalidation in mutations
     censusPrefix: ['census'] as const,
+    proposals: {
+        all: () => ['proposals'] as const
+    },
 }

--- a/client/src/components/organization/OrganizationHero.tsx
+++ b/client/src/components/organization/OrganizationHero.tsx
@@ -1,5 +1,6 @@
+import {Crown, Plus} from 'lucide-react';
+import {Link} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
-import {Crown} from 'lucide-react';
 
 import {Badge} from '@/components/ui/Badge';
 
@@ -15,6 +16,7 @@ interface Props {
     isOrganizer: boolean;
     isMember: boolean;
     stats: Stat[];
+    newProposalHref?: string;
 }
 
 function initials(name: string): string {
@@ -24,7 +26,7 @@ function initials(name: string): string {
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-export function OrganizationHero({name, description, isOrganizer, isMember, stats}: Props) {
+export function OrganizationHero({name, description, isOrganizer, isMember, stats, newProposalHref}: Props) {
     const {t} = useTranslation();
 
     return (
@@ -100,6 +102,14 @@ export function OrganizationHero({name, description, isOrganizer, isMember, stat
                                 <span className="text-xs uppercase tracking-wide text-muted">{s.label}</span>
                             </div>
                         ))}
+                        {newProposalHref && (
+                            <Link
+                                to={newProposalHref}
+                                className="ml-auto inline-flex h-10 items-center gap-2 rounded-full bg-gradient-to-br from-primary to-accent px-4 text-xs font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+                            >
+                                <Plus size={13}/> {t('proposal.new.short-title')}
+                            </Link>
+                        )}
                     </div>
                 </div>
             </div>

--- a/client/src/components/proposal/ProposalReceipt.tsx
+++ b/client/src/components/proposal/ProposalReceipt.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, Copy, Check, ExternalLink } from 'lucide-react';
+import { m, AnimatePresence, useMotionValue, useTransform } from 'framer-motion';
+
+interface ProposalReceiptProps {
+  open: boolean;
+  onViewProposal: () => void;
+  proposalTitle: string;
+  proposalId: number;
+  txId: string;
+}
+
+const LORA_BASE = 'https://lora.algokit.io/localnet/transaction';
+const DISMISS_THRESHOLD = 120;
+
+export function ProposalReceipt({ open, onViewProposal, proposalTitle, proposalId, txId }: ProposalReceiptProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const y = useMotionValue(0);
+  const opacity = useTransform(y, [0, DISMISS_THRESHOLD], [1, 0.3]);
+
+  const copyTxId = async () => {
+    try {
+      await navigator.clipboard.writeText(txId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* noop */ }
+  };
+
+  const shortTxId = txId.length > 16 ? `${txId.slice(0, 8)}...${txId.slice(-8)}` : txId;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <m.div
+            key="backdrop"
+            className="fixed inset-0 z-40 bg-fg/30 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+
+          <m.div
+            key="sheet"
+            className="fixed bottom-0 left-0 right-0 z-50 mx-auto max-w-lg rounded-t-3xl border border-border bg-surface shadow-2xl"
+            style={{ y, opacity }}
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+            drag="y"
+            dragConstraints={{ top: 0 }}
+            dragElastic={{ top: 0, bottom: 0.3 }}
+            onDragEnd={(_, info) => {
+              if (info.offset.y > DISMISS_THRESHOLD) onViewProposal();
+            }}
+          >
+            <div className="flex cursor-grab justify-center pt-4 pb-2 active:cursor-grabbing">
+              <div className="h-1 w-10 rounded-full bg-border" />
+            </div>
+
+            <div className="px-6 pb-8 pt-2">
+              <div className="mb-6 flex items-center gap-3">
+                <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-emerald-500/15">
+                  <CheckCircle2 size={26} className="text-emerald-500" />
+                </div>
+                <div>
+                  <div className="font-display text-lg font-semibold text-fg">
+                    {t('proposal.confirmed.title')}
+                  </div>
+                  <div className="text-sm text-muted">#{proposalId} · {proposalTitle}</div>
+                </div>
+              </div>
+
+              <div className="mb-6 rounded-xl border border-border bg-elevated p-3">
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted">
+                  {t('wallet.txid')}
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <code className="font-mono text-xs text-fg">{shortTxId}</code>
+                  <button
+                    onClick={copyTxId}
+                    className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-2.5 text-xs font-medium text-muted transition hover:border-primary hover:text-primary"
+                  >
+                    {copied ? <Check size={11} /> : <Copy size={11} />}
+                    {t(`common.${copied ? 'copied' : 'copy'}`)}
+                  </button>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <a
+                  href={`${LORA_BASE}/${txId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2.5 text-sm font-medium text-fg transition hover:border-primary hover:text-primary"
+                >
+                  <ExternalLink size={14} />
+                  Lora
+                </a>
+                <button
+                  onClick={onViewProposal}
+                  className="inline-flex flex-1 items-center justify-center rounded-full bg-gradient-to-br from-primary to-accent px-4 py-2.5 text-sm font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+                >
+                  {t('proposal.new.confirmed.cta')}
+                </button>
+              </div>
+            </div>
+          </m.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/client/src/components/proposal/ProposalSteps.tsx
+++ b/client/src/components/proposal/ProposalSteps.tsx
@@ -1,0 +1,355 @@
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router-dom';
+import {Plus, Trash2, Wallet, Lock, Building2} from 'lucide-react';
+
+import type {Organization, ProposalFormValues} from '@/domain';
+
+import {DateTimePicker} from '@/components/ui/DateTimePicker';
+import {Field, Input, Textarea} from '@/components/ui/Input';
+
+export const OrgStepFields = ['orgId'] as const satisfies readonly (keyof ProposalFormValues)[];
+export const BasicsStepFields = ['title', 'description'] as const satisfies readonly (keyof ProposalFormValues)[];
+export const DatesStepFields = ['startDate', 'endDate'] as const satisfies readonly (keyof ProposalFormValues)[];
+export const OptionsStepFields = ['options'] as const satisfies readonly (keyof ProposalFormValues)[];
+
+interface OptionItem {
+    id: string;
+    value: string;
+}
+
+function formatDatetime(str: string): string {
+    if (!str) return '—';
+    const d = new Date(str);
+    return isNaN(d.getTime()) ? str : d.toLocaleString(undefined, {dateStyle: 'medium', timeStyle: 'short'});
+}
+
+interface OrgStepProps {
+    isConnected: boolean;
+    eligibleOrgs: Organization[];
+    selectedOrgId: string;
+    onSelectOrg: (id: string) => void;
+}
+
+export function OrgStep({isConnected, eligibleOrgs, selectedOrgId, onSelectOrg}: OrgStepProps) {
+    const {t} = useTranslation();
+    const navigate = useNavigate();
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-muted">{t('proposal.new.org.hint')}</p>
+            {!isConnected ? (
+                <div className="flex items-center gap-2 rounded-xl border border-border bg-elevated px-4 py-3 text-sm text-muted">
+                    <Wallet size={14}/> {t('wallet.connect')}
+                </div>
+            ) : eligibleOrgs.length === 0 ? (
+                <div className="flex items-center gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400">
+                    <Lock size={14}/>
+                    <span>
+                        {t('proposal.new.org.empty')}{' '}
+                        <button
+                            type="button"
+                            onClick={() => navigate('/organizations')}
+                            className="underline hover:no-underline"
+                        >
+                            {t('proposal.new.org.browse')}
+                        </button>
+                    </span>
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {eligibleOrgs.map(org => (
+                        <label
+                            key={org.id}
+                            htmlFor={`org-${org.id}`}
+                            aria-label={org.name}
+                            className={`flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition ${
+                                selectedOrgId === String(org.id)
+                                    ? 'border-primary bg-primary/5'
+                                    : 'border-border hover:border-primary/40'
+                            }`}
+                        >
+                            <input
+                                id={`org-${org.id}`}
+                                type="radio"
+                                name="org"
+                                value={String(org.id)}
+                                checked={selectedOrgId === String(org.id)}
+                                onChange={() => onSelectOrg(String(org.id))}
+                                className="accent-primary"
+                            />
+                            <span>
+                                <span className="flex items-center gap-2 font-medium text-fg">
+                                    <Building2 size={14} className="text-muted"/>
+                                    {org.name}
+                                </span>
+                                <span className="mt-0.5 block text-xs text-muted line-clamp-1">{org.description}</span>
+                            </span>
+                        </label>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface BasicsStepProps {
+    title: string;
+    description: string;
+    onChangeTitle: (v: string) => void;
+    onChangeDescription: (v: string) => void;
+    onTouch: (field: string) => void;
+    fieldError: (field: string) => string | undefined;
+}
+
+export function BasicsStep({
+                               title,
+                               description,
+                               onChangeTitle,
+                               onChangeDescription,
+                               onTouch,
+                               fieldError,
+                           }: BasicsStepProps) {
+    const {t} = useTranslation();
+    return (
+        <>
+            <Field label={t('proposa.new.fields.title')}>
+                <Input
+                    value={title}
+                    onChange={(e) => onChangeTitle(e.target.value)}
+                    onBlur={() => onTouch('title')}
+                    placeholder={t('proposal.new.fields.title-placeholder')}
+                    className={fieldError('title') ? 'border-rose-500' : ''}
+                />
+                {fieldError('title') && (
+                    <span className="mt-1 block text-xs text-rose-500">
+                        {t(`errors.${fieldError('title')}`)}
+                    </span>
+                )}
+            </Field>
+            <Field label={t('proposal.new.fields.description')}>
+                <Textarea
+                    value={description}
+                    onChange={(e) => onChangeDescription(e.target.value)}
+                    onBlur={() => onTouch('description')}
+                    placeholder={t('proposal.new.fields.description-placeholder')}
+                    rows={5}
+                    className={fieldError('description') ? 'border-rose-500' : ''}
+                />
+                {fieldError('description') && (
+                    <span className="mt-1 block text-xs text-rose-500">
+                        {t(`errors.${fieldError('description')}`)}
+                    </span>
+                )}
+            </Field>
+        </>
+    );
+}
+
+interface DatesStepProps {
+    start: string;
+    end: string;
+    minStartDate: string;
+    showDevWarning: boolean;
+    onChangeStart: (v: string) => void;
+    onChangeEnd: (v: string) => void;
+    onTouch: (field: string) => void;
+    fieldError: (field: string) => string | undefined;
+}
+
+export function DatesStep({
+                              start,
+                              end,
+                              minStartDate,
+                              showDevWarning,
+                              onChangeStart,
+                              onChangeEnd,
+                              onTouch,
+                              fieldError,
+                          }: DatesStepProps) {
+    const {t} = useTranslation();
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-6 sm:grid-cols-2">
+                <Field label={t('proposal.new.fields.start')}>
+                    <DateTimePicker
+                        value={start}
+                        min={minStartDate}
+                        onChange={onChangeStart}
+                        onBlur={() => onTouch('startDate')}
+                        placeholder={t('proposal.new.fields.start-placeholder')}
+                        hasError={!!fieldError('startDate')}
+                    />
+                    {fieldError('startDate') && (
+                        <span className="mt-1 block text-xs text-rose-500">
+                            {t(`errors.${fieldError('startDate')}`)}
+                        </span>
+                    )}
+                </Field>
+                <Field label={t('proposal.new.fields.end')}>
+                    <DateTimePicker
+                        value={end}
+                        min={start || minStartDate}
+                        onChange={onChangeEnd}
+                        onBlur={() => onTouch('endDate')}
+                        placeholder={t('proposal.new.fields.end-placeholder')}
+                        hasError={!!fieldError('endDate')}
+                    />
+                    {fieldError('endDate') && (
+                        <span className="mt-1 block text-xs text-rose-500">
+                            {t(`errors.${fieldError('endDate')}`)}
+                        </span>
+                    )}
+                </Field>
+            </div>
+            {showDevWarning && (
+                <p className="text-xs text-muted">{t('errors.proposal.starting-too-soon')}</p>
+            )}
+        </div>
+    );
+}
+
+interface OptionsStepProps {
+    options: OptionItem[];
+    onUpdateOption: (id: string, value: string) => void;
+    onRemoveOption: (id: string) => void;
+    onAddOption: () => void;
+    onTouch: (field: string) => void;
+    fieldError: (field: string) => string | undefined;
+}
+
+export function OptionsStep({
+                                options,
+                                onUpdateOption,
+                                onRemoveOption,
+                                onAddOption,
+                                onTouch,
+                                fieldError,
+                            }: OptionsStepProps) {
+    const {t} = useTranslation();
+    return (
+        <div className="space-y-3">
+            {options.map((opt, i) => (
+                <div key={opt.id} className="flex items-center gap-3">
+                    <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                        {i + 1}
+                    </span>
+                    <Input
+                        value={opt.value}
+                        onChange={(e) => onUpdateOption(opt.id, e.target.value)}
+                        onBlur={() => onTouch('options')}
+                        placeholder={t('proposal.new.fields.option-placeholder')}
+                    />
+                    {options.length > 2 && (
+                        <button
+                            type="button"
+                            onClick={() => onRemoveOption(opt.id)}
+                            className="flex size-10 items-center justify-center rounded-full text-muted transition hover:bg-bg hover:text-rose-500"
+                            aria-label={t('proposal.new.fields.remove-option')}
+                        >
+                            <Trash2 size={16}/>
+                        </button>
+                    )}
+                </div>
+            ))}
+            {fieldError('options') && (
+                <p className="text-xs text-rose-500">
+                    {t(`errors.${fieldError('options')}`)}
+                </p>
+            )}
+            <button
+                type="button"
+                onClick={onAddOption}
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-dashed border-border px-4 text-sm text-muted transition hover:border-primary hover:text-primary"
+            >
+                <Plus size={14}/> {t('proposal.new.fields.add-option')}
+            </button>
+        </div>
+    );
+}
+
+interface ReviewStepProps {
+    orgName: string;
+    title: string;
+    description: string;
+    start: string;
+    end: string;
+    options: OptionItem[];
+    submitError: string | null;
+    submitting: boolean;
+    onRetry: () => void;
+}
+
+export function ReviewStep({
+                               orgName,
+                               title,
+                               description,
+                               start,
+                               end,
+                               options,
+                               submitError,
+                               submitting,
+                               onRetry,
+                           }: ReviewStepProps) {
+    const {t} = useTranslation();
+    return (
+        <div className="space-y-5">
+            <div>
+                <div className="text-xs font-semibold uppercase tracking-wider text-muted">{t('org.title')}</div>
+                <div className="mt-1 text-sm text-fg">{orgName}</div>
+            </div>
+            <div>
+                <div className="text-xs font-semibold uppercase tracking-wider text-muted">{t('common.title')}</div>
+                <div className="mt-1 font-display text-xl text-fg">{title || '-'}</div>
+            </div>
+            <div>
+                <div className="text-xs font-semibold uppercase tracking-wider text-muted">{t('common.description')}</div>
+                <p className="mt-1 text-sm text-muted">{description || '-'}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <div className="text-xs font-semibold uppercase tracking-wider text-muted">{t('common.start-date')}</div>
+                    <div className="mt-1 text-sm text-fg">{formatDatetime(start)}</div>
+                </div>
+                <div>
+                    <div className="text-xs font-semibold uppercase tracking-wider text-muted">{t('common.end-date')}</div>
+                    <div className="mt-1 text-sm text-fg">{formatDatetime(end)}</div>
+                </div>
+            </div>
+            <div>
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">{t('common.options')}</div>
+                <ul className="space-y-2">
+                    {options.flatMap((opt, idx) => {
+                        const trimmed = opt.value.trim();
+                        if (!trimmed) return [];
+
+                        return [
+                            <li
+                                key={opt.id}
+                                className="flex items-center gap-3 rounded-xl border border-border bg-elevated px-4 py-2 text-sm text-fg"
+                            >
+                                <span className="flex size-6 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                                    {idx + 1}
+                                </span>
+                                {trimmed}
+                            </li>,
+                        ];
+                    })}
+                </ul>
+            </div>
+
+            {submitError && (
+                <div className="space-y-2 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
+                    <p className="text-sm text-rose-500">{submitError}</p>
+                    <button
+                        type="button"
+                        onClick={onRetry}
+                        disabled={submitting}
+                        className="text-xs font-semibold text-rose-500 underline hover:no-underline disabled:opacity-50"
+                    >
+                        {t('common.submit')}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/ui/DateTimePicker.tsx
+++ b/client/src/components/ui/DateTimePicker.tsx
@@ -1,0 +1,219 @@
+import {useTranslation} from "react-i18next";
+import { AnimatePresence, m } from 'framer-motion';
+import { useMemo, useRef, useEffect, useState } from 'react';
+import { DayPicker, type ChevronProps } from 'react-day-picker';
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface DateTimePickerProps {
+  value: string;        // "YYYY-MM-DDTHH:mm" or ""
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  min?: string;         // "YYYY-MM-DDTHH:mm"
+  placeholder?: string;
+  hasError?: boolean;
+}
+
+function parseStr(str: string): Date | null {
+  if (!str) return null;
+  const d = new Date(str);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function toStr(date: Date, hour: number, minute: number): string {
+  const y = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${mo}-${d}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function NavChevron({ orientation }: ChevronProps) {
+  return orientation === 'left' ? <ChevronLeft size={15} /> : <ChevronRight size={15} />;
+}
+
+export function DateTimePicker({ value, onChange, onBlur, min, placeholder, hasError }: DateTimePickerProps) {
+  const {t} = useTranslation();
+
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Date | undefined>();
+  const [hour, setHour] = useState(12);
+  const [minute, setMinute] = useState(0);
+  const [hourStr, setHourStr] = useState('12');
+  const [minStr, setMinStr] = useState('00');
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const minDate = useMemo(() => parseStr(min ?? ''), [min]);
+
+  function handleOpen() {
+    const d = parseStr(value);
+    const h = d?.getHours() ?? 12;
+    const mi = d?.getMinutes() ?? 0;
+    setSelected(d ?? undefined);
+    setHour(h);
+    setMinute(mi);
+    setHourStr(String(h).padStart(2, '0'));
+    setMinStr(String(mi).padStart(2, '0'));
+    setOpen(true);
+  }
+
+  function handleCancel() {
+    setOpen(false);
+    onBlur?.();
+  }
+
+  function handleConfirm() {
+    if (selected) onChange(toStr(selected, hour, minute));
+    setOpen(false);
+    onBlur?.();
+  }
+
+  function commitHour(raw: string) {
+    const n = parseInt(raw, 10);
+    const v = isNaN(n) ? hour : Math.min(23, Math.max(0, n));
+    setHour(v);
+    setHourStr(String(v).padStart(2, '0'));
+  }
+
+  function commitMin(raw: string) {
+    const n = parseInt(raw, 10);
+    const v = isNaN(n) ? minute : Math.min(59, Math.max(0, n));
+    setMinute(v);
+    setMinStr(String(v).padStart(2, '0'));
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        onBlur?.();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, onBlur]);
+
+  const displayValue = useMemo(() => {
+    const d = parseStr(value);
+    return d ? d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }) : '';
+  }, [value]);
+
+  const timeInput =
+    'h-11 w-14 rounded-xl border border-border bg-surface font-mono text-2xl font-bold text-fg text-center transition ' +
+    'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary ' +
+    '[&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none [appearance:textfield]';
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => (open ? handleCancel() : handleOpen())}
+        className={[
+          'flex w-full items-center gap-2.5 rounded-xl border bg-surface px-4 py-3 text-left text-sm transition',
+          'focus:outline-none focus:ring-2 focus:ring-primary/30',
+          hasError
+            ? 'border-rose-500'
+            : open
+              ? 'border-primary ring-2 ring-primary/30'
+              : 'border-border hover:border-primary/50',
+        ].join(' ')}
+      >
+        <CalendarDays size={14} className={displayValue ? 'text-primary' : 'text-muted'} />
+        <span className={displayValue ? 'text-fg' : 'text-muted'}>
+          {displayValue || placeholder}
+        </span>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <m.div
+            initial={{ opacity: 0, y: -8, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.97 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+            className="absolute left-0 top-[calc(100%+6px)] z-50 w-[17rem] overflow-hidden rounded-2xl border border-border bg-surface shadow-2xl"
+          >
+            <DayPicker
+              mode="single"
+              selected={selected}
+              onSelect={setSelected}
+              disabled={minDate ? { before: minDate } : undefined}
+              showOutsideDays
+              classNames={{
+                root: 'px-3 pt-3 pb-1',
+                month_caption: 'flex items-center justify-between pb-3 border-b border-border mb-2',
+                caption_label: 'text-sm font-semibold capitalize text-fg',
+                nav: 'flex gap-1',
+                button_previous: 'flex size-7 items-center justify-center rounded-lg text-muted transition hover:bg-elevated hover:text-fg',
+                button_next: 'flex size-7 items-center justify-center rounded-lg text-muted transition hover:bg-elevated hover:text-fg',
+                month_grid: 'w-full',
+                weekdays: '',
+                weekday: 'py-1 text-center text-[10px] font-semibold uppercase tracking-wide text-muted',
+                weeks: '',
+                week: '',
+                day: 'p-0.5 text-center',
+                day_button: 'mx-auto flex size-8 items-center justify-center rounded-full text-xs font-medium transition text-fg hover:bg-elevated focus:outline-none',
+                selected: '[&>button]:bg-gradient-to-br [&>button]:from-primary [&>button]:to-accent [&>button]:text-primary-fg [&>button]:shadow-glow [&>button]:hover:brightness-110',
+                today: '[&>button]:border [&>button]:border-primary/50 [&>button]:font-semibold [&>button]:text-primary',
+                outside: '[&>button]:text-muted/30 [&>button]:pointer-events-none',
+                disabled: '[&>button]:text-muted/30 [&>button]:pointer-events-none',
+              }}
+              components={{ Chevron: NavChevron }}
+            />
+
+            <div className="border-t border-border bg-elevated/30 p-4">
+              <div className="flex items-center justify-center gap-3">
+                <input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={hourStr}
+                  onChange={(e) => {
+                    setHourStr(e.target.value);
+                    const n = parseInt(e.target.value, 10);
+                    if (!isNaN(n) && n >= 0 && n <= 23) setHour(n);
+                  }}
+                  onBlur={(e) => commitHour(e.target.value)}
+                  onFocus={(e) => e.target.select()}
+                  className={timeInput}
+                />
+                <span className="select-none font-mono text-2xl font-bold text-muted">:</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={59}
+                  value={minStr}
+                  onChange={(e) => {
+                    setMinStr(e.target.value);
+                    const n = parseInt(e.target.value, 10);
+                    if (!isNaN(n) && n >= 0 && n <= 59) setMinute(n);
+                  }}
+                  onBlur={(e) => commitMin(e.target.value)}
+                  onFocus={(e) => e.target.select()}
+                  className={timeInput}
+                />
+              </div>
+            </div>
+
+            <div className="flex gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="flex-1 rounded-full border border-border py-2 text-xs font-medium text-muted transition hover:border-primary/40 hover:text-fg"
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={!selected}
+                className="flex-1 rounded-full bg-gradient-to-br from-primary to-accent py-2 text-xs font-semibold text-primary-fg transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {t('common.confirm')}
+              </button>
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/client/src/components/ui/WizardLayout.tsx
+++ b/client/src/components/ui/WizardLayout.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
 import { Check } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 
 interface WizardLayoutProps<T extends string = string> {

--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -1,3 +1,6 @@
 export * from './address';
+
 export * from './organization';
 export * from './organizationDraft';
+
+export * from './proposalDraft';

--- a/client/src/domain/proposalDraft.test.ts
+++ b/client/src/domain/proposalDraft.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  proposalDraftBasicsSchema,
+  proposalDraftDatesSchema,
+  proposalDraftOptionsSchema,
+  proposalDraftSchema,
+  proposalFormSchema,
+} from './proposalDraft';
+
+const APPROVAL_BUFFER_DAYS = 3;
+
+function futureDate(daysFromNow: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function errorCodes(result: { success: boolean; error?: { issues: { message: string }[] } }): string[] {
+  if (result.success || !result.error) return [];
+  return result.error.issues.map((i) => i.message);
+}
+
+describe('proposalDraftBasicsSchema', () => {
+  it('passa amb títol i descripció no buits', () => {
+    const result = proposalDraftBasicsSchema.safeParse({ title: 'La meva proposta', description: 'Alguns detalls' });
+    expect(result.success).toBeTrue();
+  });
+
+  it('falla amb títol buit → proposal.empty-title', () => {
+    const result = proposalDraftBasicsSchema.safeParse({ title: '', description: 'Alguns detalls' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-title');
+  });
+
+  it('falla amb títol d\'espais → proposal.empty-title', () => {
+    const result = proposalDraftBasicsSchema.safeParse({ title: '   ', description: 'Alguns detalls' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-title');
+  });
+
+  it('falla amb descripció buida → proposal.empty-description', () => {
+    const result = proposalDraftBasicsSchema.safeParse({ title: 'La meva proposta', description: '' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-description');
+  });
+
+  it('falla amb descripció d\'espais → proposal.empty-description', () => {
+    const result = proposalDraftBasicsSchema.safeParse({ title: 'La meva proposta', description: '  ' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-description');
+  });
+});
+
+describe('proposalDraftDatesSchema', () => {
+  it('passa quan l\'inici és 4+ dies endavant i el final és 2+ dies després', () => {
+    const result = proposalDraftDatesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 3),
+    });
+    expect(result.success).toBeTrue();
+  });
+
+  it('falla quan l\'inici és menys de 3 dies endavant → proposal.starting-too-soon', () => {
+    const result = proposalDraftDatesSchema.safeParse({
+      startDate: futureDate(1),
+      endDate: futureDate(5),
+    });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.starting-too-soon');
+  });
+
+  it('falla quan el final és igual a l\'inici → proposal.small-voting-window', () => {
+    const start = futureDate(APPROVAL_BUFFER_DAYS + 1);
+    const result = proposalDraftDatesSchema.safeParse({
+      startDate: start,
+      endDate: new Date(start),
+    });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.small-voting-window');
+  });
+
+  it('falla quan el final és menys d\'1 dia després de l\'inici → proposal.small-voting-window', () => {
+    const result = proposalDraftDatesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 1.9),
+    });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.small-voting-window');
+  });
+
+  it('passa quan el final és més d\'1 dia després de l\'inici', () => {
+    const result = proposalDraftDatesSchema.safeParse({
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 4),
+    });
+    expect(result.success).toBeTrue();
+  });
+});
+
+describe('proposalDraftOptionsSchema', () => {
+  it('passa amb 2 opcions úniques no buides', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['Opció A', 'Opció B'] });
+    expect(result.success).toBeTrue();
+  });
+
+  it('falla amb només 1 opció → proposal.too-few-options', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['Només una'] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.too-few-options');
+  });
+
+  it('falla amb 0 opcions → proposal.too-few-options', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: [] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.too-few-options');
+  });
+
+  it('falla amb una opció buida → proposal.empty-options', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['Opció A', 'Opció B', ''] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-options');
+  });
+
+  it('falla amb una opció d\'espais → proposal.empty-options', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['Opció A', 'Opció B', '   '] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-options');
+  });
+
+  it('falla amb opcions duplicades (insensible a majúscules) → proposal.duplicated-options', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['Opció A', 'opció a'] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.duplicated-options');
+  });
+
+  it('passa amb 3 opcions úniques', () => {
+    const result = proposalDraftOptionsSchema.safeParse({ options: ['A', 'B', 'C'] });
+    expect(result.success).toBeTrue();
+  });
+});
+
+describe('proposalDraftSchema (complet)', () => {
+  it('passa amb totes les dades vàlides', () => {
+    const result = proposalDraftSchema.safeParse({
+      title: 'La meva proposta',
+      description: 'Una descripció detallada',
+      startDate: futureDate(APPROVAL_BUFFER_DAYS + 1),
+      endDate: futureDate(APPROVAL_BUFFER_DAYS + 3),
+      options: ['Opció A', 'Opció B'],
+    });
+    expect(result.success).toBeTrue();
+  });
+
+  it('informa de tots els errors quan tot és invàlid', () => {
+    const result = proposalDraftSchema.safeParse({
+      title: '',
+      description: '',
+      startDate: futureDate(1),
+      endDate: futureDate(1),
+      options: ['única'],
+    });
+    expect(result.success).toBeFalse();
+    const codes = errorCodes(result);
+    expect(codes).toContain('proposal.empty-title');
+    expect(codes).toContain('proposal.empty-description');
+    expect(codes).toContain('proposal.starting-too-soon');
+    expect(codes).toContain('proposal.too-few-options');
+  });
+});
+
+describe('proposalFormSchema', () => {
+  // startDate i endDate són cadenes en format datetime-local.
+  // Dates al futur llunyà per evitar el marge d'aprovació de 3 dies en validació de producció.
+  const VALID_START = '2099-01-01T00:00';
+  const VALID_END = '2099-01-05T00:00';
+
+  function validBase() {
+    return {
+      orgId: '1',
+      title: 'La meva proposta',
+      description: 'Una descripció',
+      startDate: VALID_START,
+      endDate: VALID_END,
+      options: [{ value: 'Opció A' }, { value: 'Opció B' }],
+    };
+  }
+
+  it('passa amb totes les dades vàlides', () => {
+    expect(proposalFormSchema.safeParse(validBase()).success).toBeTrue();
+  });
+
+  it('falla amb orgId buit → org.required', () => {
+    const result = proposalFormSchema.safeParse({ ...validBase(), orgId: '' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('org.required');
+  });
+
+  it('falla amb startDate buit → proposal.starting-too-soon', () => {
+    const result = proposalFormSchema.safeParse({ ...validBase(), startDate: '' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.starting-too-soon');
+  });
+
+  it('falla amb endDate buit → proposal.small-voting-window', () => {
+    const result = proposalFormSchema.safeParse({ ...validBase(), endDate: '' });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.small-voting-window');
+  });
+
+  it('falla amb opcions duplicades (insensible a majúscules) → proposal.duplicated-options', () => {
+    const result = proposalFormSchema.safeParse({
+      ...validBase(),
+      options: [{ value: 'Opció A' }, { value: 'opció a' }],
+    });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.duplicated-options');
+  });
+
+  it('falla amb una opció en blanc → proposal.empty-options', () => {
+    const result = proposalFormSchema.safeParse({
+      ...validBase(),
+      options: [{ value: 'Opció A' }, { value: 'Opció B' }, { value: '' }],
+    });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.empty-options');
+  });
+
+  it('falla amb una sola opció → proposal.too-few-options', () => {
+    const result = proposalFormSchema.safeParse({ ...validBase(), options: [{ value: 'Única' }] });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.too-few-options');
+  });
+
+  it('falla quan startDate és en el futur proper (per sota del marge d\'aprovació) → proposal.starting-too-soon', () => {
+    const futureProper = futureDate(1).toISOString().slice(0, 16);
+    const result = proposalFormSchema.safeParse({ ...validBase(), startDate: futureProper });
+    expect(result.success).toBeFalse();
+    expect(errorCodes(result)).toContain('proposal.starting-too-soon');
+  });
+});

--- a/client/src/domain/proposalDraft.ts
+++ b/client/src/domain/proposalDraft.ts
@@ -1,0 +1,90 @@
+import * as z from 'zod';
+
+const APPROVAL_BUFFER_DAYS = 3;
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+
+// Dev: any past/future start, 1-minute voting window suffices.
+// Prod: start ≥ APPROVAL_BUFFER_DAYS ahead, window ≥ 1 hour.
+const DEV = import.meta.env.DEV;
+
+function minStartDate(): Date {
+  if (DEV) return new Date(0);
+  return new Date(Date.now() + APPROVAL_BUFFER_DAYS * MS_PER_DAY);
+}
+
+export const proposalDraftBasicsSchema = z.object({
+  title: z.string().trim().min(1, { message: 'proposal.empty-title' }),
+  description: z.string().trim().min(1, { message: 'proposal.empty-description' }),
+});
+
+function addDateIssues(
+  startDate: Date,
+  endDate: Date,
+  addIssue: (params: { code: 'custom'; message: string; path: string[] }) => void,
+): void {
+  if (startDate < minStartDate()) {
+    addIssue({ code: 'custom', message: 'proposal.starting-too-soon', path: ['startDate'] });
+  }
+  const minEnd = DEV ? startDate : new Date(startDate.getTime() + MS_PER_HOUR);
+  if (endDate <= minEnd) {
+    addIssue({ code: 'custom', message: 'proposal.small-voting-window', path: ['endDate'] });
+  }
+}
+
+export const proposalDraftDatesSchema = z
+  .object({
+    startDate: z.date(),
+    endDate: z.date(),
+  })
+  .superRefine((data, ctx) => {
+    addDateIssues(data.startDate, data.endDate, (issue) => ctx.addIssue(issue));
+  });
+
+function hasDuplicateOptions(values: string[]): boolean {
+  const lower = values.map((v) => v.toLowerCase());
+  return new Set(lower).size !== lower.length;
+}
+
+export const proposalDraftOptionsSchema = z.object({
+  options: z
+    .array(z.string().trim().min(1, { message: 'proposal.empty-options' }))
+    .min(2, { message: 'proposal.too-few-options' })
+    .refine((opts) => !hasDuplicateOptions(opts), { message: 'proposal.duplicated-options' }),
+});
+
+export const proposalDraftSchema = proposalDraftBasicsSchema
+  .and(proposalDraftDatesSchema)
+  .and(proposalDraftOptionsSchema);
+
+type ProposalDraft = z.infer<typeof proposalDraftSchema>;
+
+// Form-level schema for react-hook-form: dates are strings (from datetime-local inputs).
+// Date validation delegates to proposalDraftDatesSchema to avoid duplication.
+export const proposalFormSchema = z
+  .object({
+    orgId: z.string().min(1, { message: 'org.required' }),
+    title: z.string().trim().min(1, { message: 'proposal.empty-title' }),
+    description: z.string().trim().min(1, { message: 'proposal.empty-description' }),
+    startDate: z.string().min(1, { message: 'proposal.starting-too-soon' }),
+    endDate: z.string().min(1, { message: 'proposal.small-voting-window' }),
+    options: z
+      .array(z.object({ value: z.string().trim().min(1, { message: 'proposal.empty-options' }) }))
+      .min(2, { message: 'proposal.too-few-options' })
+      .refine(
+        (opts) => {
+          const vals = opts.flatMap((o) => { const v = o.value.toLowerCase().trim(); return v ? [v] : []; });
+          return !hasDuplicateOptions(vals);
+        },
+        { message: 'proposal.duplicated-options' },
+      ),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.startDate || !data.endDate) return;
+    const startDate = new Date(data.startDate);
+    const endDate = new Date(data.endDate);
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
+    addDateIssues(startDate, endDate, (issue) => ctx.addIssue(issue));
+  });
+
+export type ProposalFormValues = z.infer<typeof proposalFormSchema>;

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -9,6 +9,7 @@
   "common": {
     "title": "Títol",
     "cancel": "Cancel·la",
+    "confirm": "Confirma",
     "back": "Enrere",
     "previous": "Anterior",
     "next": "Següent",
@@ -23,6 +24,11 @@
     "disconnect": "Desconnectar",
     "step": "Pas {{current}} de {{total}}",
     "proposals": "Propostes",
+    "org": "Organització",
+    "basics": "Bàsics",
+    "dates": "Dates",
+    "options": "Opcions",
+    "review": "Revisió",
     "member": "Membre",
     "members": "Membres",
     "organizer": "Organitzador",
@@ -30,7 +36,11 @@
     "add": "Afegir",
     "remove": "Eliminar",
     "replace-all": "Substituir tot",
-    "progress": "Processant {{done}} / {{total}}"
+    "progress": "Processant {{done}} / {{total}}",
+    "start-date": "Data d'inici",
+    "end-date": "Data de fi",
+    "copied": "Copiat!",
+    "copy": "Copia"
   },
   "theme": {
     "toggle": "Canvia el tema",
@@ -170,8 +180,39 @@
       "text": "Això substituirà els {{current}} membres actuals de \"{{name}}\" per {{next}} noves adreces. Aquesta acció no es pot desfer."
     }
   },
+  "proposal": {
+    "new": {
+      "title": "Crea una nova proposta",
+      "short-title": "Nove proposta",
+      "submit": "Publica la proposta",
+      "org": {
+        "hint": "Selecciona l'organització a la qual pertanyerà aquesta proposta.",
+        "empty": "No ets membre de cap organització.",
+        "browse": "Explora les organitzacions"
+      },
+      "fields": {
+        "title": "Títol de la proposta",
+        "title-placeholder": "p. ex. Beca comunitària 2026",
+        "description": "Descripció",
+        "description-placeholder": "Descriu què decidiran els votants…",
+        "start": "La votació comença",
+        "start-placeholder": "Selecciona inici",
+        "end": "La votació acaba",
+        "end-placeholder": "Selecciona fi",
+        "option": "Opció {{n}}",
+        "option-placeholder": "Descriu una opció",
+        "add-option": "Afegeix opció",
+        "remove-option": "Elimina"
+      },
+      "confirmed": {
+        "title": "Proposta publicada!",
+        "cta": "Veure la proposta"
+      }
+    }
+  },
   "wallet": {
-    "connect": "Connecta el wallet per enviar",
+    "txid": "ID de transacció",
+    "connect": "Connecta el wallet per continuar",
     "choose": "Estria wallet",
     "switch": "Canviar de compte",
     "address-filter-placeholder": "Filtrar per adreça…",
@@ -179,6 +220,8 @@
   },
   "errors": {
     "unknown": "Error desconegut",
+    "network": "Error de xarxa. Torna-ho a intentar.",
+    "contract": "Error desconegut de provinent de la cadena de blocs",
     "proposal": {
       "empty-title": "El títol no pot estar buit",
       "empty-description": "La descripció no pot estar buida",
@@ -188,9 +231,11 @@
       "empty-options": "Cap opció pot estar buida",
       "duplicated-options": "Hi ha opcions duplicades"
     },
+    "org": {
+      "required": "S'ha d'especificar l'ID d'una organització"
+    },
     "wallet": {
-      "rejected": "Has cancel·lat la signatura",
-      "network": "Error de xarxa. Torna-ho a intentar."
+      "rejected": "Has cancel·lat la signatura"
     }
   }
 }

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
   "common": {
     "title": "Title",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "back": "Back",
     "previous": "Previous",
     "next": "Next",
@@ -23,6 +24,11 @@
     "disconnect": "Disconnect",
     "step": "Step {{current}} of {{total}}",
     "proposals": "Proposals",
+    "org": "Organization",
+    "basics": "Basics",
+    "dates": "Dates",
+    "options": "Options",
+    "review": "Review",
     "member": "Member",
     "members": "Members",
     "organizer": "Organizer",
@@ -30,7 +36,11 @@
     "add": "Add",
     "remove": "Remove",
     "replace-all": "Replace all",
-    "progress": "Processing {{done}} / {{total}}"
+    "progress": "Processing {{done}} / {{total}}",
+    "start-date": "Start date",
+    "end-date": "End Date",
+    "copied": "Copied!",
+    "copy": "Copy"
   },
   "theme": {
     "toggle": "Toggle theme",
@@ -170,8 +180,39 @@
       "text": "This will replace {{current}} current members of \"{{name}}\" with {{next}} new addresses. This action cannot be undone."
     }
   },
+  "proposal": {
+    "new": {
+      "title": "Start a new proposal",
+      "short-title": "New proposal",
+      "submit": "Publish proposal",
+      "org": {
+        "hint": "Select the organization this proposal will belong to.",
+        "empty": "You are not a member of any organization.",
+        "browse": "Browse organizations"
+      },
+      "fields": {
+        "title": "Proposal title",
+        "title-placeholder": "e.g. Community grant recipient 2026",
+        "description": "Description",
+        "description-placeholder": "Describe what voters will be deciding…",
+        "start": "Voting starts",
+        "start-placeholder": "Select starting",
+        "end": "Voting ends",
+        "end-placeholder": "Select ending",
+        "option": "Option {{n}}",
+        "option-placeholder": "Describe an option",
+        "add-option": "Add option",
+        "remove-option": "Remove"
+      },
+      "confirmed": {
+        "title": "Proposal published!",
+        "cta": "See the proposal"
+      }
+    }
+  },
   "wallet": {
-    "connect": "Connect the wallet to send",
+    "txid": "Transaction ID",
+    "connect": "Connect the wallet to continue",
     "choose": "Choose wallet",
     "switch": "Switch account",
     "address-filter-placeholder": "Filter by address…",
@@ -179,6 +220,8 @@
   },
   "errors": {
     "unknown": "Unknown error",
+    "network": "Network error. Please try again.",
+    "contract": "Unknown error originating from the blockchain",
     "proposal": {
       "empty-title": "Title cannot be empty",
       "empty-description": "Description cannot be empty",
@@ -188,9 +231,11 @@
       "empty-options": "No option can be empty",
       "duplicated-options": "There are duplicate options"
     },
+    "org": {
+      "required": "An organization ID must be specified"
+    },
     "wallet": {
-      "rejected": "You cancelled the signature",
-      "network": "Network error. Please try again."
+      "rejected": "You cancelled the signature"
     }
   }
 }

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -9,6 +9,7 @@
   "common": {
     "title": "Título",
     "cancel": "Cancelar",
+    "confirm": "Confirma",
     "back": "Atrás",
     "previous": "Anterior",
     "next": "Siguiente",
@@ -23,6 +24,11 @@
     "disconnect": "Desconectar",
     "step": "Paso {{current}} de {{total}}",
     "proposals": "Propuestas",
+    "org": "Organización",
+    "basics": "Básicos",
+    "dates": "Fechas",
+    "options": "Opciones",
+    "review": "Revisión",
     "member": "Miembro",
     "members": "Miembros",
     "organizer": "Organizador",
@@ -30,7 +36,11 @@
     "add": "Añadir",
     "remove": "Eliminar",
     "replace-all": "Remplazar todo",
-    "progress": "Procesando {{done}} / {{total}}"
+    "progress": "Procesando {{done}} / {{total}}",
+    "start-date": "Fecha de inicio",
+    "end-date": "Fecha de finalización",
+    "copied": "¡Copiado!",
+    "copy": "Copia"
   },
   "theme": {
     "toggle": "Cambiar tema",
@@ -170,8 +180,39 @@
       "text": "Esto reemplazará a los {{count}} miembros actuales de \"{{name}}\" por {{next}} nuevas direcciones. Esta acción no puede deshacerse."
     }
   },
+  "proposal": {
+    "new": {
+      "title": "Crear una nueva propuesta",
+      "short-title": "Nueva propuesta",
+      "submit": "Publicar propuesta",
+      "org": {
+        "hint": "Selecciona la organización a la que pertenecerá esta propuesta.",
+        "empty": "No eres miembro de ninguna organización.",
+        "browse": "Explorar organizaciones"
+      },
+      "fields": {
+        "title": "Título de la propuesta",
+        "title-placeholder": "p. ej. Beca comunitaria 2026",
+        "description": "Descripción",
+        "description-placeholder": "Describe qué van a decidir los votantes…",
+        "start": "La votación empieza",
+        "start-placeholder": "Selecciona inicio",
+        "end": "La votación termina",
+        "end-placeholder": "Selecciona final",
+        "option": "Opción {{n}}",
+        "option-placeholder": "Describe una opción",
+        "add-option": "Añadir opción",
+        "remove-option": "Quitar"
+      },
+      "confirmed": {
+        "title": "¡Propuesta publicada!",
+        "cta": "Ver la propuesta"
+      }
+    }
+  },
   "wallet": {
-    "connect": "Conecta la wallet para enviar",
+    "txid": "ID de transacción",
+    "connect": "Conecta la wallet para continuar",
     "choose": "Escoger wallet",
     "switch": "Cambiar de cuenta",
     "address-filter-placeholder": "Filtrar por dirección…",
@@ -179,6 +220,8 @@
   },
   "errors": {
     "unknown": "Error desconocido",
+    "network": "Error de red. Inténtalo de nuevo.",
+    "contract": "Error desconocido originado en la cadena de bloques",
     "proposal": {
       "empty-title": "El título no puede estar vacío",
       "empty-description": "La descripción no puede estar vacía",
@@ -188,9 +231,11 @@
       "empty-options": "Ninguna opción puede estar vacía",
       "duplicated-options": "Hay opciones duplicadas"
     },
+    "org": {
+      "required": "Debe especificarse un ID de organización"
+    },
     "wallet": {
-      "rejected": "Has cancelado la firma",
-      "network": "Error de red. Inténtalo de nuevo."
+      "rejected": "Has cancelado la firma"
     }
   }
 }

--- a/client/src/pages/NewProposalPage.tsx
+++ b/client/src/pages/NewProposalPage.tsx
@@ -1,0 +1,283 @@
+import {useState} from 'react';
+import {useNavigate, useSearchParams} from 'react-router-dom';
+
+import {ArrowLeft, ArrowRight, Check, Wallet} from 'lucide-react';
+import {useTranslation} from 'react-i18next';
+
+import {useQuery} from '@tanstack/react-query';
+
+import {useForm, useFieldArray} from 'react-hook-form';
+import {zodResolver} from '@hookform/resolvers/zod';
+
+import {ProposalReceipt} from '@/components/proposal/ProposalReceipt';
+
+import {WizardLayout} from '@/components/ui/WizardLayout';
+import {Button} from '@/components/ui/Button';
+
+import {
+    BasicsStep,
+    DatesStep,
+    OptionsStep,
+    OrgStep,
+    ReviewStep,
+    OrgStepFields,
+    BasicsStepFields,
+    DatesStepFields,
+    OptionsStepFields,
+} from '@/components/proposal/ProposalSteps';
+
+import {proposalFormSchema, type ProposalFormValues} from '@/domain';
+
+import {useAlgorand} from '@/hooks/useAlgorand';
+import {useWizard} from '@/hooks/useWizard';
+
+import {organizationQueries} from '@/algorand/queries';
+
+const STEPS = ['org', 'basics', 'dates', 'options', 'review'] as const;
+
+const DEV = import.meta.env.DEV;
+const APPROVAL_BUFFER_DAYS = 3;
+
+function minStartDateStr(): string {
+    if (DEV) return '';
+    const d = new Date();
+    d.setDate(d.getDate() + APPROVAL_BUFFER_DAYS);
+    d.setHours(0, 0, 0, 0);
+    return d.toISOString().slice(0, 16);
+}
+
+function classifyError(err: unknown): 'wallet.rejected' | 'network' | 'contract' | 'unknown' {
+    const msg = err instanceof Error ? err.message.toLowerCase() : '';
+    if (msg.includes('cancel') || msg.includes('rejected') || msg.includes('user rejected')) return 'wallet.rejected';
+    if (msg.includes('network') || msg.includes('timeout') || msg.includes('fetch')) return 'network';
+    if (err instanceof Error && err.message.startsWith('proposal.')) return 'contract';
+    return 'unknown';
+}
+
+const STEP_FIELDS = [
+    OrgStepFields,
+    BasicsStepFields,
+    DatesStepFields,
+    OptionsStepFields,
+    [],
+] as const;
+
+export function NewProposalPage() {
+    const {t} = useTranslation();
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const {address, isConnected, signer} = useAlgorand();
+
+    const {data: eligibleOrgs = []} = useQuery({
+        ...organizationQueries.forUser(address!),
+        enabled: address !== null,
+    });
+
+    const preselectedOrgId = searchParams.get('org') ?? '';
+
+    const initialOrgId = String(
+        eligibleOrgs.find((o) => String(o.id) === preselectedOrgId)?.id ?? eligibleOrgs[0]?.id ?? '',
+    );
+
+    const {
+        watch,
+        setValue,
+        trigger,
+        control,
+        getValues,
+        formState: {errors},
+    } = useForm<ProposalFormValues>({
+        resolver: zodResolver(proposalFormSchema),
+        defaultValues: {
+            orgId: initialOrgId,
+            title: '',
+            description: '',
+            startDate: '',
+            endDate: '',
+            options: [{value: ''}, {value: ''}],
+        },
+    });
+
+    const {fields, append, remove} = useFieldArray({control, name: 'options'});
+
+    const wizard = useWizard(STEPS.length);
+    const [proposalId, setProposalId] = useState<number | null>(null);
+    const [confirmedTxId, setConfirmedTxId] = useState('');
+
+    const orgId = watch('orgId');
+    const title = watch('title');
+    const description = watch('description');
+    const startDate = watch('startDate');
+    const endDate = watch('endDate');
+
+    const watchedOptions = watch('options');
+
+    const canNext =
+        wizard.step === 0 ? !!orgId && eligibleOrgs.length > 0
+            : wizard.step === 1 ? !!(title.trim() && description.trim())
+                : wizard.step === 2 ? !!(startDate && endDate)
+                    : wizard.step === 3 ? watchedOptions.filter((o) => o?.value?.trim()).length >= 2
+                        : true;
+
+    function fieldError(field: string): string | undefined {
+        if (field === 'options') return errors.options?.message;
+        const key = field as Exclude<keyof ProposalFormValues, 'options'>;
+        return errors[key]?.message;
+    }
+
+    async function tryAdvance() {
+        const stepFields = STEP_FIELDS[wizard.step];
+        const valid = stepFields.length > 0 ? await trigger(stepFields as unknown as (keyof ProposalFormValues)[]) : true;
+        if (valid) wizard.next();
+    }
+
+    function onTouch(field: string) {
+        void trigger(field as keyof ProposalFormValues);
+    }
+
+    const handleSubmit = async () => {
+        if (!isConnected || !address || !orgId) return;
+        wizard.startSubmit();
+
+        try {
+            // TODO
+            //setProposalId(newId);
+            //setConfirmedTxId(txId);
+            wizard.succeedSubmit();
+        } catch (err) {
+            const kind = classifyError(err);
+
+            const messageKey = kind === 'contract' && err instanceof Error ? err.message : kind;
+
+            wizard.failSubmit(t(`errors.${messageKey}`));
+        }
+    };
+
+    if (proposalId !== null) {
+        return (
+            <>
+                <div className="mx-auto max-w-3xl px-6 py-14 opacity-40 pointer-events-none select-none">
+                    <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">
+                        {t('common.step', {current: STEPS.length, total: STEPS.length})}
+                    </div>
+                    <h1 className="mb-8 font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+                        {t('proposal.new.title')}
+                    </h1>
+                </div>
+                <ProposalReceipt
+                    open
+                    proposalTitle={title}
+                    proposalId={proposalId}
+                    txId={confirmedTxId}
+                    onViewProposal={() => navigate(`/proposals/${proposalId}`)}
+                />
+            </>
+        );
+    }
+
+    const optionItems = fields.map((f, idx) => ({id: f.id, value: watchedOptions[idx]?.value ?? ''}));
+
+    return (
+        <div className="mx-auto max-w-3xl px-6 py-14">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">
+                {t('common.step', {current: wizard.step + 1, total: STEPS.length})}
+            </div>
+            <h1 className="mb-8 font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+                {t('proposal.new.title')}
+            </h1>
+
+            <WizardLayout
+                steps={STEPS}
+                currentStep={wizard.step}
+                stepLabel={s => t(`common.${s}`)}
+                submitError={wizard.error}
+                footer={
+                    <>
+                        <Button
+                            variant="ghost"
+                            onClick={wizard.prev}
+                            disabled={wizard.isFirst || wizard.submitting}
+                            leftIcon={<ArrowLeft size={16}/>}
+                        >
+                            {t('common.previous')}
+                        </Button>
+
+                        {!wizard.isLast ? (
+                            <Button onClick={tryAdvance} disabled={!canNext} rightIcon={<ArrowRight size={16}/>}>
+                                {t('common.next')}
+                            </Button>
+                        ) : !isConnected ? (
+                            <span className="flex items-center gap-1.5 text-sm text-muted">
+                                <Wallet size={14}/> {t('wallet.connect')}
+                            </span>
+                        ) : (
+                            <Button rightIcon={<Check size={16}/>} onClick={handleSubmit} disabled={wizard.submitting}>
+                                {wizard.submitting ? t('wallet.waiting-signature') : t('proposal.new.submit')}
+                            </Button>
+                        )}
+                    </>
+                }
+            >
+                {wizard.step === 0 && (
+                    <OrgStep
+                        isConnected={isConnected}
+                        eligibleOrgs={eligibleOrgs}
+                        selectedOrgId={orgId}
+                        onSelectOrg={(id) => setValue('orgId', id)}
+                    />
+                )}
+                {wizard.step === 1 && (
+                    <BasicsStep
+                        title={title}
+                        description={description}
+                        onChangeTitle={(v) => setValue('title', v)}
+                        onChangeDescription={(v) => setValue('description', v)}
+                        onTouch={onTouch}
+                        fieldError={fieldError}
+                    />
+                )}
+                {wizard.step === 2 && (
+                    <DatesStep
+                        start={startDate}
+                        end={endDate}
+                        minStartDate={minStartDateStr()}
+                        showDevWarning={!DEV}
+                        onChangeStart={(v) => setValue('startDate', v)}
+                        onChangeEnd={(v) => setValue('endDate', v)}
+                        onTouch={onTouch}
+                        fieldError={fieldError}
+                    />
+                )}
+                {wizard.step === 3 && (
+                    <OptionsStep
+                        options={optionItems}
+                        onUpdateOption={(id, value) => {
+                            const idx = fields.findIndex((f) => f.id === id);
+                            if (idx !== -1) setValue(`options.${idx}.value`, value);
+                        }}
+                        onRemoveOption={(id) => {
+                            const idx = fields.findIndex((f) => f.id === id);
+                            if (idx !== -1) remove(idx);
+                        }}
+                        onAddOption={() => append({value: ''})}
+                        onTouch={onTouch}
+                        fieldError={fieldError}
+                    />
+                )}
+                {wizard.step === 4 && (
+                    <ReviewStep
+                        orgName={eligibleOrgs.find((o) => String(o.id) === orgId)?.name ?? '-'}
+                        title={title}
+                        description={description}
+                        start={startDate}
+                        end={endDate}
+                        options={optionItems}
+                        submitError={wizard.error}
+                        submitting={wizard.submitting}
+                        onRetry={handleSubmit}
+                    />
+                )}
+            </WizardLayout>
+        </div>
+    );
+}

--- a/client/src/pages/OrganizationDetailPage.tsx
+++ b/client/src/pages/OrganizationDetailPage.tsx
@@ -114,6 +114,9 @@ export function OrganizationDetailPage() {
                 isOrganizer={isOrganizer}
                 isMember={isMember}
                 stats={stats}
+                newProposalHref={
+                    isMember || isOrganizer ? `/proposals/new?org=${organization.id}` : undefined
+                }
             />
 
             {!isMember && !isOrganizer && (

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -13,6 +13,8 @@ import {OrganizationsPage} from "@/pages/OrganizationsPage";
 import {NewOrganizationPage} from "@/pages/NewOrganizationPage";
 import {OrganizationDetailPage} from "@/pages/OrganizationDetailPage";
 
+import {NewProposalPage} from "@/pages/NewProposalPage";
+
 import {parseRouteId} from "@/hooks/utils.ts";
 
 export const router = createBrowserRouter([{
@@ -50,6 +52,10 @@ export const router = createBrowserRouter([{
         {
             path: '/organizations/new',
             element: <NewOrganizationPage/>
+        },
+        {
+            path: '/proposals/new',
+            element: <NewProposalPage/>
         },
     ],
 }]);


### PR DESCRIPTION
## Descripció del canvi

Implementa el *wizard* multi-pas per crear propostes, organitzat en quatre passes: (1) selecció d'organització, (2) títol i descripció, (3) dates d'inici i fi amb un `DateTimePicker` a mida, i (4) opcions de votació. El pas final mostra un resum complet i, un cop enviada la transacció, apareix un *bottom sheet* animat (`ProposalReceipt`) amb l'ID de la proposta i l'enllaç a la transacció a Lora. Cada pas valida els camps amb l'*schema* Zod i desactiva el botó "Següent" fins que les dades siguin vàlides; la navegació enrere preserva tot l'estat introduït.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #314

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal