### PR TITLE
feat(client): connectar el wizard de propostes amb el contracte

### DIFF
--- a/client/src/algorand/_contract.ts
+++ b/client/src/algorand/_contract.ts
@@ -37,6 +37,8 @@ export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 // Prefixos descodificats des dels valors en base64 d'ARC-56 :
 //   organizations:    "org_"      (b3JnXw==)         4 bytes + uint64 = 12 bytes
 //   census:           "cs_"       (Y3Nf)             3 bytes + uint64 + pubkey = 43 bytes
+//   proposals:        "proposals" (cHJvcG9zYWxz)   9 bytes + uint64 = 17 bytes
+//   approval_tallies: "at_"       (YXRf)             3 bytes + uint64 = 11 bytes
 
 
 export function orgBoxKey(id: number): Uint8Array {
@@ -57,6 +59,14 @@ export function censusBoxKey(orgId: number, member: string): Uint8Array {
         ...algosdk.bigIntToBytes(orgId, 8),
         ...algosdk.decodeAddress(member).publicKey,
     ]);
+}
+
+export function proposalBoxKey(id: number): Uint8Array {
+    return new Uint8Array([...enc.encode('proposals'), ...algosdk.bigIntToBytes(id, 8)]);
+}
+
+export function tallyBoxKey(id: number): Uint8Array {
+    return new Uint8Array([...enc.encode('at_'), ...algosdk.bigIntToBytes(id, 8)]);
 }
 
 // ── Definicions dels mètodes ABI ───────────────────────────────────────────
@@ -86,6 +96,19 @@ export const removeFromCensusMethod = new algosdk.ABIMethod({
         {type: 'address[]', name: 'members'},
     ],
     returns: {type: 'void'},
+});
+
+export const createProposalMethod = new algosdk.ABIMethod({
+    name: 'create_proposal',
+    args: [
+        { type: 'uint64', name: 'org_id' },
+        { type: 'string', name: 'title' },
+        { type: 'string', name: 'description' },
+        { type: 'string[]', name: 'options' },
+        { type: 'uint64', name: 'starting_date' },
+        { type: 'uint64', name: 'ending_date' },
+    ],
+    returns: { type: 'uint64' },
 });
 
 // ── Executor ATC ─────────────────────────────────────────────────────

--- a/client/src/algorand/mutations.ts
+++ b/client/src/algorand/mutations.ts
@@ -3,6 +3,8 @@ import type algosdk from 'algosdk';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {createOrganization, addToCensus, removeFromCensus} from './organizations';
+import {createProposal} from "./proposals";
+
 import {queryKeys} from './queryKeys';
 
 // ── Shared argument shapes ───────────────────────────────────────────
@@ -21,6 +23,15 @@ interface CensusArgs extends SignerArgs {
     orgId: number;
     members: string[];
     onProgress?: (done: number, total: number) => void;
+}
+
+interface CreateProposalArgs extends SignerArgs {
+    orgId: number;
+    title: string;
+    description: string;
+    options: string[];
+    startingDate: number;
+    endingDate: number;
 }
 
 // ── Mutation hooks ───────────────────────────────────────────────────
@@ -62,6 +73,19 @@ export function useRemoveFromCensus() {
         onSuccess: (_data, { orgId }) => {
             void queryClient.invalidateQueries({ queryKey: queryKeys.organizations.detail(orgId) });
             void queryClient.invalidateQueries({ queryKey: queryKeys.censusPrefix });
+        },
+    });
+}
+
+export function useCreateProposal() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ signer, sender, orgId, title, description, options, startingDate, endingDate }: CreateProposalArgs) => {
+            return createProposal(signer, sender, orgId, title, description, options, startingDate, endingDate)
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() });
         },
     });
 }

--- a/client/src/algorand/proposals.ts
+++ b/client/src/algorand/proposals.ts
@@ -1,0 +1,43 @@
+import { APP_ID } from './config';
+
+import {
+  proposalBoxKey,
+  tallyBoxKey,
+  orgBoxKey,
+  censusBoxKey,
+  createProposalMethod,
+  callMethod,
+  readGlobalUint64,
+  type TransactionSigner,
+} from './_contract';
+
+export async function createProposal(
+  signer: TransactionSigner,
+  sender: string,
+  orgId: number,
+  title: string,
+  description: string,
+  options: string[],
+  startingDate: number,
+  endingDate: number,
+): Promise<{ proposalId: number; txId: string }> {
+  const currentProposalId = await readGlobalUint64('proposal_id');
+  const nextId = currentProposalId + 1;
+
+  // create_proposal calls _assert_in_census, so census box is required too.
+  const result = await callMethod(
+    signer,
+    sender,
+    createProposalMethod,
+    [BigInt(orgId), title, description, options, BigInt(startingDate), BigInt(endingDate)],
+    [
+      { appIndex: APP_ID, name: proposalBoxKey(nextId) },
+      { appIndex: APP_ID, name: tallyBoxKey(nextId) },
+      { appIndex: APP_ID, name: orgBoxKey(orgId) },
+      { appIndex: APP_ID, name: censusBoxKey(orgId, sender) },
+    ],
+  );
+
+  const proposalId = Number(result.returnValue as bigint);
+  return { proposalId, txId: result.txID };
+}

--- a/client/src/pages/NewProposalPage.tsx
+++ b/client/src/pages/NewProposalPage.tsx
@@ -32,6 +32,9 @@ import {useAlgorand} from '@/hooks/useAlgorand';
 import {useWizard} from '@/hooks/useWizard';
 
 import {organizationQueries} from '@/algorand/queries';
+import {useCreateProposal} from '@/algorand/mutations';
+
+import {dateToUnix} from '@/utils/date';
 
 const STEPS = ['org', 'basics', 'dates', 'options', 'review'] as const;
 
@@ -74,6 +77,7 @@ export function NewProposalPage() {
     });
 
     const preselectedOrgId = searchParams.get('org') ?? '';
+    const createProposalMutation = useCreateProposal();
 
     const initialOrgId = String(
         eligibleOrgs.find((o) => String(o.id) === preselectedOrgId)?.id ?? eligibleOrgs[0]?.id ?? '',
@@ -140,9 +144,27 @@ export function NewProposalPage() {
         wizard.startSubmit();
 
         try {
-            // TODO
-            //setProposalId(newId);
-            //setConfirmedTxId(txId);
+            const values = getValues();
+            const startUnix = dateToUnix(new Date(values.startDate));
+            const endUnix = dateToUnix(new Date(values.endDate));
+            const cleanOptions = values.options.flatMap((o) => {
+                const trimmed = o.value.trim();
+                return trimmed ? [trimmed] : [];
+            });
+
+            const {proposalId: newId, txId} = await createProposalMutation.mutateAsync({
+                signer,
+                sender: address,
+                orgId: parseInt(orgId, 10),
+                title: values.title,
+                description: values.description,
+                options: cleanOptions,
+                startingDate: startUnix,
+                endingDate: endUnix,
+            });
+
+            setProposalId(newId);
+            setConfirmedTxId(txId);
             wizard.succeedSubmit();
         } catch (err) {
             const kind = classifyError(err);

--- a/client/src/utils/date.test.ts
+++ b/client/src/utils/date.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'bun:test';
+import { dateToUnix, formatDate, formatDatetime } from './date';
+
+describe('dateToUnix', () => {
+  it('converteix l\'época Unix a 0', () => {
+    expect(dateToUnix(new Date(0))).toBe(0);
+  });
+
+  it('converteix un timestamp conegut correctament', () => {
+    // 2024-01-01T00:00:00.000Z → 1704067200
+    expect(dateToUnix(new Date('2024-01-01T00:00:00.000Z'))).toBe(1704067200);
+  });
+
+  it('trunca els mil·lisegons (floor, no round)', () => {
+    // 1999 ms → 1 segon complet (no arrodoneix a 2)
+    expect(dateToUnix(new Date(1999))).toBe(1);
+  });
+
+  it('gestiona timestamps a mig segon truncant-los', () => {
+    expect(dateToUnix(new Date(500))).toBe(0);
+  });
+});
+
+describe('formatDate', () => {
+  const UNIX_2024 = 1704067200; // 2024-01-01T00:00:00.000Z
+
+  it("formata amb locale 'en' i conté l'any 2024", () => {
+    const result = formatDate(UNIX_2024, 'en');
+    expect(result).toContain('2024');
+  });
+
+  it("formata amb locale 'ca' sense llançar cap error", () => {
+    expect(() => formatDate(UNIX_2024, 'ca')).not.toThrow();
+  });
+
+  it("formata amb locale 'es' sense llançar cap error", () => {
+    expect(() => formatDate(UNIX_2024, 'es')).not.toThrow();
+  });
+
+  it('retrocedeix a l\'anglès per a un locale desconegut', () => {
+    const resultDesconegut = formatDate(UNIX_2024, 'xx');
+    const resultEn = formatDate(UNIX_2024, 'en');
+    expect(resultDesconegut).toBe(resultEn);
+  });
+
+  it('retorna una cadena de text formatada (no el número brut)', () => {
+    const result = formatDate(UNIX_2024, 'en');
+    expect(typeof result).toBe('string');
+    expect(result).not.toBe(String(UNIX_2024));
+  });
+});
+
+describe('formatDatetime', () => {
+  // 2024-01-01T12:00:00.000Z
+  const UNIX_NOON = 1704110400;
+
+  it("formata amb locale 'en' i conté l'any 2024", () => {
+    const result = formatDatetime(UNIX_NOON, 'en');
+    expect(result).toContain('2024');
+  });
+
+  it("formata amb locale 'en' i conté els minuts (':00')", () => {
+    const result = formatDatetime(UNIX_NOON, 'en');
+    expect(result).toContain(':00');
+  });
+
+  it("formata amb locale 'ca' sense llançar cap error", () => {
+    expect(() => formatDatetime(UNIX_NOON, 'ca')).not.toThrow();
+  });
+
+  it("formata amb locale 'es' sense llançar cap error", () => {
+    expect(() => formatDatetime(UNIX_NOON, 'es')).not.toThrow();
+  });
+
+  it('retrocedeix a l\'anglès per a un locale desconegut', () => {
+    const resultDesconegut = formatDatetime(UNIX_NOON, 'xx');
+    const resultEn = formatDatetime(UNIX_NOON, 'en');
+    expect(resultDesconegut).toBe(resultEn);
+  });
+
+  it('retorna una cadena de text formatada (no el número brut)', () => {
+    const result = formatDatetime(UNIX_NOON, 'en');
+    expect(typeof result).toBe('string');
+    expect(result).not.toBe(String(UNIX_NOON));
+  });
+});

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,0 +1,45 @@
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+};
+
+const DATETIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+};
+
+const fmtEn = new Intl.DateTimeFormat('en', DATE_FORMAT_OPTIONS);
+const fmtCa = new Intl.DateTimeFormat('ca', DATE_FORMAT_OPTIONS);
+const fmtEs = new Intl.DateTimeFormat('es', DATE_FORMAT_OPTIONS);
+const dateFormatters: Record<string, Intl.DateTimeFormat> = { en: fmtEn, ca: fmtCa, es: fmtEs };
+
+const fmtEnDt = new Intl.DateTimeFormat('en', DATETIME_FORMAT_OPTIONS);
+const fmtCaDt = new Intl.DateTimeFormat('ca', DATETIME_FORMAT_OPTIONS);
+const fmtEsDt = new Intl.DateTimeFormat('es', DATETIME_FORMAT_OPTIONS);
+const datetimeFormatters: Record<string, Intl.DateTimeFormat> = { en: fmtEnDt, ca: fmtCaDt, es: fmtEsDt };
+
+export function dateToUnix(d: Date): number {
+  return Math.floor(d.getTime() / 1000);
+}
+
+/** Formats a UNIX-seconds timestamp in the given locale (date only). */
+export function formatDate(unixSeconds: number, locale: string): string {
+  try {
+    return (dateFormatters[locale] ?? fmtEn).format(new Date(unixSeconds * 1000));
+  } catch {
+    return String(unixSeconds);
+  }
+}
+
+/** Formats a UNIX-seconds timestamp with date and time in the given locale. */
+export function formatDatetime(unixSeconds: number, locale: string): string {
+  try {
+    return (datetimeFormatters[locale] ?? fmtEnDt).format(new Date(unixSeconds * 1000));
+  } catch {
+    return String(unixSeconds);
+  }
+}


### PR DESCRIPTION
## Descripció del canvi

Connecta el *wizard* de creació de propostes amb el contracte intel·ligent d'Algorand. S'implementa `createProposal` a `proposals.ts`, que construeix la crida ABI `create_proposal` amb les referències de *box* correctes (proposta, tally, organització i cens). S'afegeixen els schemas Zod de validació del formulari (`proposalDraftSchema`) amb regles cross-camp per a les dates (prod: inici ≥ 3 dies, finestra ≥ 1h; dev: relaxat), i utilitats de formatació de dates localitzades a `utils/date.ts`.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #315

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal