### PR TITLE
feat(client): pàgina de detall de la proposta

### DIFF
--- a/client/src/algorand/mappers.ts
+++ b/client/src/algorand/mappers.ts
@@ -1,6 +1,6 @@
-import type { OnChainOrganization } from './wire';
-import type { Organization } from '@/domain';
-import { asOrganizationId, asAddress } from '@/domain';
+import {asAddress, type Proposal, asProposalId, computeProposalState, type Organization, asOrganizationId} from '@/domain';
+
+import type {OnChainApprovalTally, OnChainOrganization, OnChainProposal} from './wire';
 
 export function mapToOrganization(
   id: number,
@@ -12,6 +12,37 @@ export function mapToOrganization(
     name: onChain.name,
     description: onChain.description,
     organizer: asAddress(onChain.organizer),
+    memberCount,
+  };
+}
+
+export function mapToProposal(
+    id: number,
+    onChain: OnChainProposal,
+    tally: OnChainApprovalTally,
+    memberCount: number,
+    now = Math.floor(Date.now() / 1000),
+): Proposal {
+  const approvalTally = { votesFor: tally.votesFor, totalVotes: tally.totalVotes };
+
+  const state = computeProposalState({
+    now,
+    startDate: onChain.startingDate,
+    endDate: onChain.endingDate,
+    approvalTally,
+    memberCount,
+  });
+
+  return {
+    id: asProposalId(id),
+    orgId: asOrganizationId(onChain.orgId),
+    title: onChain.title,
+    description: onChain.description,
+    options: onChain.options.map((title, i) => ({ id: i, title })),
+    startDate: onChain.startingDate,
+    endDate: onChain.endingDate,
+    state,
+    approvalTally,
     memberCount,
   };
 }

--- a/client/src/algorand/organizations.ts
+++ b/client/src/algorand/organizations.ts
@@ -1,6 +1,8 @@
 import algosdk from 'algosdk';
 
-import type {OnChainOrganization} from "@/algorand/wire";
+import {Address, asAddress, asOrganizationId, OrganizationId} from "@/domain";
+
+import type {OnChainOrganization} from "./wire";
 import {algodClient, APP_ID} from './config';
 
 import {
@@ -22,12 +24,12 @@ import {
 
 export async function createOrganization(
     signer: TransactionSigner,
-    sender: string,
+    sender: Address,
     name: string,
     description: string,
-): Promise<{ orgId: number; txId: string }> {
-    const currentOrgId = await readGlobalUint64('org_id');
-    const nextId = currentOrgId + 1;
+): Promise<{ orgId: OrganizationId; txId: string }> {
+    const currentOrgId = asOrganizationId(await readGlobalUint64('org_id'));
+    const nextId = asOrganizationId(currentOrgId + 1);
 
     const suggestedParams = await algodClient.getTransactionParams().do();
     const appAddress = algosdk.getApplicationAddress(APP_ID);
@@ -68,14 +70,15 @@ export async function createOrganization(
     try {
         const result = await composer.execute(algodClient, 4);
         const methodResult = result.methodResults[0];
-        const orgId = Number(methodResult.returnValue as bigint);
+        const orgId = asOrganizationId(Number(methodResult.returnValue));
+
         return {orgId, txId: methodResult.txID};
     } catch (err) {
         throw decodeContractError(err);
     }
 }
 
-export async function getOrganization(orgId: number): Promise<OnChainOrganization | null> {
+export async function getOrganization(orgId: OrganizationId): Promise<OnChainOrganization | null> {
     try {
         const box = await algodClient.getApplicationBoxByName(APP_ID, orgBoxKey(orgId)).do();
         return decodeOrganization(box.value);
@@ -84,17 +87,17 @@ export async function getOrganization(orgId: number): Promise<OnChainOrganizatio
     }
 }
 
-export async function getAllOrganizationIds(): Promise<number[]> {
+export async function getAllOrganizationIds(): Promise<OrganizationId[]> {
     try {
         const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
         const orgPrefix = enc.encode('org_'); // 4 bytes
-        const ids: number[] = [];
+        const ids: OrganizationId[] = [];
 
         for (const box of boxes) {
             const name = box.name;
             // org_ box names: "org_" (4) + uint64 (8) = 12 bytes
             if (name.length === 12 && bytesEqual(name.slice(0, 4), orgPrefix)) {
-                const id = Number(algosdk.bytesToBigInt(name.slice(4)));
+                const id = asOrganizationId(Number(algosdk.bytesToBigInt(name.slice(4))));
                 if (id > 0) ids.push(id);
             }
         }
@@ -107,16 +110,16 @@ export async function getAllOrganizationIds(): Promise<number[]> {
 
 export async function addToCensus(
     signer: TransactionSigner,
-    sender: string,
-    orgId: number,
-    members: string[],
+    sender: Address,
+    orgId: OrganizationId,
+    members: Address[],
     onProgress?: (done: number, total: number) => void,
 ): Promise<void> {
     if (members.length === 0) return;
 
     const appAddress = algosdk.getApplicationAddress(APP_ID);
 
-    const batches: string[][] = [];
+    const batches: Address[][] = [];
 
     for (let i = 0; i < members.length; i += CENSUS_BATCH) {
         batches.push(members.slice(i, i + CENSUS_BATCH));
@@ -163,9 +166,9 @@ export async function addToCensus(
 
 export async function removeFromCensus(
     signer: TransactionSigner,
-    sender: string,
-    orgId: number,
-    members: string[],
+    sender: Address,
+    orgId: OrganizationId,
+    members: Address[],
 ): Promise<void> {
     if (members.length === 0) return;
 
@@ -174,6 +177,7 @@ export async function removeFromCensus(
 
     for (let i = 0; i < members.length; i += CENSUS_BATCH) {
         const batch = members.slice(i, i + CENSUS_BATCH);
+
         composer.addMethodCall({
             appID: APP_ID,
             method: removeFromCensusMethod,
@@ -195,12 +199,12 @@ export async function removeFromCensus(
     }
 }
 
-export async function getCensusMembers(orgId: number): Promise<string[]> {
+export async function getCensusMembers(orgId: OrganizationId): Promise<Address[]> {
     try {
         const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
         const prefix = enc.encode('cs_'); // 3 bytes
         const orgIdBytes = algosdk.bigIntToBytes(orgId, 8);
-        const members: string[] = [];
+        const members: Address[] = [];
 
         for (const box of boxes) {
             const name = box.name;
@@ -210,7 +214,7 @@ export async function getCensusMembers(orgId: number): Promise<string[]> {
                 bytesEqual(name.slice(0, 3), prefix) &&
                 bytesEqual(name.slice(3, 11), orgIdBytes)
             ) {
-                members.push(algosdk.encodeAddress(name.slice(11)));
+                members.push(asAddress(algosdk.encodeAddress(name.slice(11))));
             }
         }
 
@@ -220,11 +224,12 @@ export async function getCensusMembers(orgId: number): Promise<string[]> {
     }
 }
 
-export async function getCensusMemberCount(orgId: number): Promise<number> {
+export async function getCensusMemberCount(orgId: OrganizationId): Promise<number> {
     try {
         const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
         const prefix = enc.encode('cs_');
         const orgIdBytes = algosdk.bigIntToBytes(orgId, 8);
+
         return boxes.filter(
             (box) =>
                 box.name.length === 43 &&
@@ -236,7 +241,7 @@ export async function getCensusMemberCount(orgId: number): Promise<number> {
     }
 }
 
-export async function isInCensusChain(address: string, orgId: number): Promise<boolean> {
+export async function isInCensusChain(address: Address, orgId: OrganizationId): Promise<boolean> {
     return singleBoxExists(censusBoxKey(orgId, address));
 }
 
@@ -245,10 +250,10 @@ function decodeOrganization(data: Uint8Array): OnChainOrganization {
     const decoded = type.decode(data) as [bigint, string, string, string];
 
     return {
-        orgId: Number(decoded[0]),
+        orgId: asOrganizationId(Number(decoded[0])),
         name: decoded[1],
         description: decoded[2],
-        organizer: decoded[3],
+        organizer: asAddress(decoded[3]),
         memberCount: 0,
     };
 }

--- a/client/src/algorand/proposals.ts
+++ b/client/src/algorand/proposals.ts
@@ -1,4 +1,9 @@
-import { APP_ID } from './config';
+import algosdk from "algosdk";
+
+import {asOrganizationId} from "@/domain";
+
+import type {OnChainApprovalTally, OnChainProposal} from "./wire";
+import {algodClient, APP_ID} from './config';
 
 import {
   proposalBoxKey,
@@ -40,4 +45,48 @@ export async function createProposal(
 
   const proposalId = Number(result.returnValue as bigint);
   return { proposalId, txId: result.txID };
+}
+
+export async function getProposal(proposalId: number): Promise<OnChainProposal | null> {
+    try {
+        const box = await algodClient.getApplicationBoxByName(APP_ID, proposalBoxKey(proposalId)).do();
+        return decodeProposal(box.value);
+    } catch {
+        return null;
+    }
+}
+
+export async function getApprovalTally(proposalId: number): Promise<OnChainApprovalTally | null> {
+    try {
+        const box = await algodClient.getApplicationBoxByName(APP_ID, tallyBoxKey(proposalId)).do();
+        return decodeTally(box.value);
+    } catch {
+        return null;
+    }
+}
+
+// Proposal ARC-4 type: (uint64, string, string, string[], uint64, uint64)
+function decodeProposal(data: Uint8Array): OnChainProposal {
+    const type = algosdk.ABIType.from('(uint64,string,string,string[],uint64,uint64)');
+    const decoded = type.decode(data) as [bigint, string, string, string[], bigint, bigint];
+
+    return {
+        orgId: asOrganizationId(Number(decoded[0])),
+        title: decoded[1],
+        description: decoded[2],
+        options: decoded[3],
+        startingDate: Number(decoded[4]),
+        endingDate: Number(decoded[5]),
+    };
+}
+
+// ApprovalTally ARC-4 type: (uint32, uint32)
+function decodeTally(data: Uint8Array): OnChainApprovalTally {
+    const type = algosdk.ABIType.from('(uint32,uint32)');
+    const decoded = type.decode(data) as [bigint, bigint];
+
+    return {
+        votesFor: Number(decoded[0]),
+        totalVotes: Number(decoded[1]),
+    };
 }

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -1,4 +1,7 @@
 import {queryOptions} from '@tanstack/react-query';
+
+import type {Address, Organization, OrganizationId, Proposal, ProposalId} from '@/domain';
+
 import {
     getOrganization,
     getAllOrganizationIds,
@@ -7,14 +10,18 @@ import {
     isInCensusChain
 } from './organizations';
 
-import type {Organization} from '@/domain';
+import {
+    getApprovalTally,
+    getProposal
+} from "./proposals";
 
-import {mapToOrganization} from './mappers';
+import {mapToOrganization, mapToProposal} from './mappers';
+import type {OnChainApprovalTally} from "./wire";
 import {queryKeys} from './queryKeys';
 
 // ── Fetchers asíncrons ────────────────────────────────────────────────────
 
-async function fetchOrganization(id: number): Promise<Organization | null> {
+async function fetchOrganization(id: OrganizationId): Promise<Organization | null> {
     const onChain = await getOrganization(id);
     if (!onChain) return null;
     const memberCount = await getCensusMemberCount(id);
@@ -27,11 +34,11 @@ async function fetchOrganizations(): Promise<Organization[]> {
     return results.filter((o): o is Organization => o !== null);
 }
 
-async function fetchCensusMembers(orgId: number): Promise<string[]> {
+async function fetchCensusMembers(orgId: OrganizationId): Promise<string[]> {
     return getCensusMembers(orgId);
 }
 
-async function fetchUserOrganizations(address: string): Promise<Organization[]> {
+async function fetchUserOrganizations(address: Address): Promise<Organization[]> {
     const ids = await getAllOrganizationIds();
 
     const results = await Promise.all(
@@ -45,6 +52,15 @@ async function fetchUserOrganizations(address: string): Promise<Organization[]> 
     return results.filter((o): o is Organization => o !== null);
 }
 
+async function fetchProposal(id: ProposalId): Promise<Proposal | null> {
+    const onChain = await getProposal(id);
+    if (!onChain) return null;
+    const tally = await getApprovalTally(id);
+    if (!tally) return null;
+    const memberCount = await getCensusMemberCount(onChain.orgId);
+    return mapToProposal(id, onChain, tally as OnChainApprovalTally, memberCount);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -52,16 +68,23 @@ export const organizationQueries = {
         queryKey: queryKeys.organizations.all(),
         queryFn: fetchOrganizations,
     }),
-    detail: (id: number) => queryOptions({
+    detail: (id: OrganizationId) => queryOptions({
         queryKey: queryKeys.organizations.detail(id),
         queryFn: () => fetchOrganization(id),
     }),
-    census: (id: number) => queryOptions({
+    census: (id: OrganizationId) => queryOptions({
         queryKey: queryKeys.organizations.census(id),
         queryFn: () => fetchCensusMembers(id),
     }),
-    forUser: (address: string) => queryOptions({
+    forUser: (address: Address) => queryOptions({
         queryKey: queryKeys.organizations.forUser(address),
         queryFn: () => fetchUserOrganizations(address),
+    }),
+};
+
+export const proposalQueries = {
+    detail: (id: ProposalId) => queryOptions({
+        queryKey: queryKeys.proposals.detail(id),
+        queryFn: () => fetchProposal(id),
     }),
 };

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -1,13 +1,16 @@
+import type {Address, OrganizationId, ProposalId} from "@/domain";
+
 export const queryKeys = {
     organizations: {
         all: () => ['organizations'] as const,
-        detail: (id: number) => ['organizations', id] as const,
-        census: (id: number) => ['organizations', id, 'census'] as const,
-        forUser: (address: string) => ['organizations', 'user', address] as const,
+        detail: (id: OrganizationId) => ['organizations', id] as const,
+        census: (id: OrganizationId) => ['organizations', id, 'census'] as const,
+        forUser: (address: Address) => ['organizations', 'user', address] as const,
     },
     // Prefix keys for broad namespace invalidation in mutations
     censusPrefix: ['census'] as const,
     proposals: {
-        all: () => ['proposals'] as const
+        all: () => ['proposals'] as const,
+        detail: (id: ProposalId) => ['proposals', id] as const
     },
 }

--- a/client/src/algorand/wire.ts
+++ b/client/src/algorand/wire.ts
@@ -3,11 +3,31 @@
 // El codi fora de 'src/algorand/' no hauria d'importar-se d'aquí; hauria de consumir de 'src/domain/'.
 
 // ARC-56 Organization struct: (uint64, string, string, address, uint32)
+import type {Address, OrganizationId} from "@/domain";
+
 export interface OnChainOrganization {
-  orgId: number;
+  orgId: OrganizationId;
   name: string;
   description: string;
   /** Adreça Algorand (58-char base32). */
-  organizer: string;
+  organizer: Address;
   memberCount: number;
+}
+
+// ARC-56 Proposal struct: (uint64, string, string, string[], uint64, uint64)
+export interface OnChainProposal {
+  orgId: OrganizationId;
+  title: string;
+  description: string;
+  options: string[];
+  /** UNIX seconds. */
+  startingDate: number;
+  /** UNIX seconds. */
+  endingDate: number;
+}
+
+// ARC-56 ApprovalTally struct: (uint32, uint32)
+export interface OnChainApprovalTally {
+  votesFor: number;
+  totalVotes: number;
 }

--- a/client/src/components/proposal/ApprovalBar.tsx
+++ b/client/src/components/proposal/ApprovalBar.tsx
@@ -1,0 +1,55 @@
+import {Check} from 'lucide-react';
+import {useTranslation} from 'react-i18next';
+
+interface Props {
+    yes: number;
+    total: number;
+    compact?: boolean;
+}
+
+const THRESHOLD_PERCENTAGE = 2 / 3;
+
+export function ApprovalBar({yes, total, compact = false}: Props) {
+    const {t} = useTranslation();
+
+    const percentage = total > 0 ? (yes / total) * 100 : 0;
+    const reached = percentage >= THRESHOLD_PERCENTAGE;
+
+    return (
+        <div className="w-full">
+            {!compact && (
+                <div className="mb-2 flex items-center justify-between text-xs">
+                    <span className="font-medium text-muted">{t('proposals.approval.label')}</span>
+                    <span className="tabular-nums text-muted">
+                        {t('common.completeness', {current: yes, total})}
+                    </span>
+                </div>
+            )}
+            <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-border/70">
+                <div
+                    className={`absolute inset-y-0 left-0 rounded-full transition-all ${
+                        reached ? 'bg-emerald-500' : 'bg-gradient-to-r from-primary to-accent'
+                    }`}
+                    style={{width: `${Math.min(percentage, 100)}%`}}
+                />
+                {/* 2/3 marker */}
+                <div
+                    className="absolute top-1/2 h-4 w-0.5 -translate-y-1/2 bg-fg/70"
+                    style={{left: `${THRESHOLD_PERCENTAGE}%`}}
+                    aria-hidden
+                />
+            </div>
+            {!compact && (
+                <div className="mt-1.5 flex items-center justify-between text-xs">
+                    <span className="text-muted">{t('proposals.approval.threshold')}</span>
+                    {reached && (
+                        <span className="inline-flex items-center gap-1 font-medium text-emerald-500">
+                            <Check size={12}/>
+                            {t('proposal.approval.reached')}
+                        </span>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/proposal/StatusBadge.tsx
+++ b/client/src/components/proposal/StatusBadge.tsx
@@ -1,0 +1,40 @@
+import type {ComponentType} from "react";
+import {useTranslation} from 'react-i18next';
+import {Clock, CheckCircle2, Vote, Archive, XCircle} from 'lucide-react';
+
+import type {ProposalStateKind} from '@/domain';
+
+import {Badge} from '@/components/ui/Badge';
+
+const STATUS_I18N_KEY = {
+    PendingApproval: 'pending',
+    Rejected: 'rejected',
+    PendingStart: 'approved',
+    Open: 'voting',
+    Closed: 'closed',
+} as const satisfies Record<ProposalStateKind, string>;
+
+const map: Record<ProposalStateKind, {
+    tone: 'warning' | 'primary' | 'success' | 'neutral' | 'danger';
+    icon: ComponentType<{ size?: number }>
+}> = {
+    PendingApproval: {tone: 'warning', icon: Clock},
+    Rejected: {tone: 'danger', icon: XCircle},
+    PendingStart: {tone: 'primary', icon: CheckCircle2},
+    Open: {tone: 'success', icon: Vote},
+    Closed: {tone: 'neutral', icon: Archive},
+};
+
+export function StatusBadge({status}: { status: ProposalStateKind }) {
+    const {t} = useTranslation();
+
+    const conf = map[status];
+    const Icon = conf.icon;
+
+    return (
+        <Badge tone={conf.tone}>
+            <Icon size={12}/>
+            {t(`proposal.status.${STATUS_I18N_KEY[status]}`)}
+        </Badge>
+    );
+}

--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -3,4 +3,6 @@ export * from './address';
 export * from './organization';
 export * from './organizationDraft';
 
+export * from './proposal';
 export * from './proposalDraft';
+export * from './proposalState'

--- a/client/src/domain/organizationDraft.ts
+++ b/client/src/domain/organizationDraft.ts
@@ -1,8 +1,8 @@
 import * as z from 'zod';
 
 export const organizationDraftSchema = z.object({
-  name: z.string().trim().min(1, { message: 'org.empty-name' }),
-  description: z.string().trim().min(1, { message: 'org.empty-description' }),
+    name: z.string().trim().min(1, {error: 'org.empty-name'}),
+    description: z.string().trim().min(1, {error: 'org.empty-description'}),
 });
 
 export type OrganizationDraft = z.infer<typeof organizationDraftSchema>;

--- a/client/src/domain/proposal.ts
+++ b/client/src/domain/proposal.ts
@@ -1,0 +1,45 @@
+import * as z from 'zod';
+
+import type {ApprovalTally, ProposalState} from "./proposalState";
+import {organizationIdSchema} from "./organization";
+
+declare const proposalIdBrand: unique symbol;
+export type ProposalId = number & { readonly [proposalIdBrand]: true };
+
+const proposalIdSchema = z
+    .number()
+    .int()
+    .nonnegative()
+    .transform((n): ProposalId => n as ProposalId);
+
+export function asProposalId(n: number): ProposalId {
+  return proposalIdSchema.parse(n);
+}
+
+const proposalOptionSchema = z.object({
+  id: z.number().int().nonnegative(),
+  title: z.string(),
+  description: z.string().optional(),
+});
+
+export type ProposalOption = z.infer<typeof proposalOptionSchema>;
+
+const proposalBaseSchema = z.object({
+  id: proposalIdSchema,
+  orgId: organizationIdSchema,
+  title: z.string(),
+  description: z.string(),
+  options: z.array(proposalOptionSchema),
+  /** UNIX seconds. */
+  startDate: z.number().int().nonnegative(),
+  /** UNIX seconds. */
+  endDate: z.number().int().nonnegative(),
+});
+
+type ProposalBase = z.infer<typeof proposalBaseSchema>;
+
+export type Proposal = ProposalBase & {
+  state: ProposalState;
+  approvalTally: ApprovalTally;
+  memberCount: number;
+};

--- a/client/src/domain/proposalDraft.ts
+++ b/client/src/domain/proposalDraft.ts
@@ -9,82 +9,85 @@ const MS_PER_HOUR = 3_600_000;
 const DEV = import.meta.env.DEV;
 
 function minStartDate(): Date {
-  if (DEV) return new Date(0);
-  return new Date(Date.now() + APPROVAL_BUFFER_DAYS * MS_PER_DAY);
+    if (DEV) return new Date(0);
+    return new Date(Date.now() + APPROVAL_BUFFER_DAYS * MS_PER_DAY);
 }
 
 export const proposalDraftBasicsSchema = z.object({
-  title: z.string().trim().min(1, { message: 'proposal.empty-title' }),
-  description: z.string().trim().min(1, { message: 'proposal.empty-description' }),
+    title: z.string().trim().min(1, {error: 'proposal.empty-title'}),
+    description: z.string().trim().min(1, {error: 'proposal.empty-description'}),
 });
 
 function addDateIssues(
-  startDate: Date,
-  endDate: Date,
-  addIssue: (params: { code: 'custom'; message: string; path: string[] }) => void,
+    startDate: Date,
+    endDate: Date,
+    addIssue: (params: { code: 'custom'; message: string; path: string[] }) => void,
 ): void {
-  if (startDate < minStartDate()) {
-    addIssue({ code: 'custom', message: 'proposal.starting-too-soon', path: ['startDate'] });
-  }
-  const minEnd = DEV ? startDate : new Date(startDate.getTime() + MS_PER_HOUR);
-  if (endDate <= minEnd) {
-    addIssue({ code: 'custom', message: 'proposal.small-voting-window', path: ['endDate'] });
-  }
+    if (startDate < minStartDate()) {
+        addIssue({code: 'custom', message: 'proposal.starting-too-soon', path: ['startDate']});
+    }
+    const minEnd = DEV ? startDate : new Date(startDate.getTime() + MS_PER_HOUR);
+    if (endDate <= minEnd) {
+        addIssue({code: 'custom', message: 'proposal.small-voting-window', path: ['endDate']});
+    }
 }
 
 export const proposalDraftDatesSchema = z
-  .object({
-    startDate: z.date(),
-    endDate: z.date(),
-  })
-  .superRefine((data, ctx) => {
-    addDateIssues(data.startDate, data.endDate, (issue) => ctx.addIssue(issue));
-  });
+    .object({
+        startDate: z.date(),
+        endDate: z.date(),
+    })
+    .superRefine((data, ctx) => {
+        addDateIssues(data.startDate, data.endDate, (issue) => ctx.addIssue(issue));
+    });
 
 function hasDuplicateOptions(values: string[]): boolean {
-  const lower = values.map((v) => v.toLowerCase());
-  return new Set(lower).size !== lower.length;
+    const lower = values.map((v) => v.toLowerCase());
+    return new Set(lower).size !== lower.length;
 }
 
 export const proposalDraftOptionsSchema = z.object({
-  options: z
-    .array(z.string().trim().min(1, { message: 'proposal.empty-options' }))
-    .min(2, { message: 'proposal.too-few-options' })
-    .refine((opts) => !hasDuplicateOptions(opts), { message: 'proposal.duplicated-options' }),
+    options: z
+        .array(z.string().trim().min(1, {error: 'proposal.empty-options'}))
+        .min(2, {error: 'proposal.too-few-options'})
+        .refine((opts) => !hasDuplicateOptions(opts), {error: 'proposal.duplicated-options'}),
 });
 
 export const proposalDraftSchema = proposalDraftBasicsSchema
-  .and(proposalDraftDatesSchema)
-  .and(proposalDraftOptionsSchema);
+    .and(proposalDraftDatesSchema)
+    .and(proposalDraftOptionsSchema);
 
 type ProposalDraft = z.infer<typeof proposalDraftSchema>;
 
 // Form-level schema for react-hook-form: dates are strings (from datetime-local inputs).
 // Date validation delegates to proposalDraftDatesSchema to avoid duplication.
 export const proposalFormSchema = z
-  .object({
-    orgId: z.string().min(1, { message: 'org.required' }),
-    title: z.string().trim().min(1, { message: 'proposal.empty-title' }),
-    description: z.string().trim().min(1, { message: 'proposal.empty-description' }),
-    startDate: z.string().min(1, { message: 'proposal.starting-too-soon' }),
-    endDate: z.string().min(1, { message: 'proposal.small-voting-window' }),
-    options: z
-      .array(z.object({ value: z.string().trim().min(1, { message: 'proposal.empty-options' }) }))
-      .min(2, { message: 'proposal.too-few-options' })
-      .refine(
-        (opts) => {
-          const vals = opts.flatMap((o) => { const v = o.value.toLowerCase().trim(); return v ? [v] : []; });
-          return !hasDuplicateOptions(vals);
-        },
-        { message: 'proposal.duplicated-options' },
-      ),
-  })
-  .superRefine((data, ctx) => {
-    if (!data.startDate || !data.endDate) return;
-    const startDate = new Date(data.startDate);
-    const endDate = new Date(data.endDate);
-    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
-    addDateIssues(startDate, endDate, (issue) => ctx.addIssue(issue));
-  });
+    .object({
+        orgId: z.string().min(1, {error: 'org.required'}),
+        title: z.string().trim().min(1, {error: 'proposal.empty-title'}),
+        description: z.string().trim().min(1, {error: 'proposal.empty-description'}),
+        startDate: z.string().min(1, {error: 'proposal.starting-too-soon'}),
+        endDate: z.string().min(1, {error: 'proposal.small-voting-window'}),
+        options: z
+            .array(z.object({value: z.string().trim().min(1, {error: 'proposal.empty-options'})}))
+            .min(2, {error: 'proposal.too-few-options'})
+            .refine(
+                (opts) => {
+                    const vals = opts.flatMap((o) => {
+                        const v = o.value.toLowerCase().trim();
+                        return v ? [v] : [];
+                    });
+                    return !hasDuplicateOptions(vals);
+                },
+                {error: 'proposal.duplicated-options'},
+            ),
+    })
+    .superRefine((data, ctx) => {
+        if (!data.startDate || !data.endDate) return;
+        const startDate = new Date(data.startDate);
+        const endDate = new Date(data.endDate);
+        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
+        addDateIssues(startDate, endDate, (issue) => ctx.addIssue(issue));
+    });
 
 export type ProposalFormValues = z.infer<typeof proposalFormSchema>;

--- a/client/src/domain/proposalState.test.ts
+++ b/client/src/domain/proposalState.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'bun:test';
+import { computeProposalState, isApproved } from './proposalState';
+
+const HORA = 3600;
+const DIA = 24 * HORA;
+
+describe('isApproved', () => {
+  it('retorna false quan memberCount és zero', () => {
+    expect(isApproved({ votesFor: 0, totalVotes: 0 }, 0)).toBeFalse();
+  });
+
+  it('retorna true exactament al llindar 2/3', () => {
+    // 2 de 3 → 3·2 = 6 ≥ 2·3 = 6
+    expect(isApproved({ votesFor: 2, totalVotes: 2 }, 3)).toBeTrue();
+  });
+
+  it('retorna false just per sota del llindar 2/3', () => {
+    // 1 de 3 → 3·1 = 3 < 2·3 = 6
+    expect(isApproved({ votesFor: 1, totalVotes: 1 }, 3)).toBeFalse();
+  });
+
+  it('retorna true quan votesFor supera 2/3', () => {
+    expect(isApproved({ votesFor: 5, totalVotes: 5 }, 6)).toBeTrue();
+  });
+});
+
+describe('computeProposalState', () => {
+  const ara = 1_700_000_000;
+
+  it('retorna PendingApproval quan és abans de startDate i per sota del llindar', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara + DIA,
+      endDate: ara + 2 * DIA,
+      approvalTally: { votesFor: 0, totalVotes: 0 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('PendingApproval');
+    if (estat.kind === 'PendingApproval') {
+      expect(estat.approvalTally.votesFor).toBe(0);
+      expect(estat.memberCount).toBe(10);
+    }
+  });
+
+  it('retorna PendingStart quan s\'ha assolit el llindar però és abans de startDate', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara + DIA,
+      endDate: ara + 2 * DIA,
+      approvalTally: { votesFor: 7, totalVotes: 7 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('PendingStart');
+  });
+
+  it('retorna Open quan s\'ha assolit el llindar i s\'és dins la finestra de votació', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara - HORA,
+      endDate: ara + DIA,
+      approvalTally: { votesFor: 7, totalVotes: 7 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('Open');
+  });
+
+  it('retorna Rejected quan ha passat startDate sense assolir el llindar', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara - HORA,
+      endDate: ara + DIA,
+      approvalTally: { votesFor: 2, totalVotes: 5 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('Rejected');
+    if (estat.kind === 'Rejected') {
+      expect(estat.approvalTally.votesFor).toBe(2);
+      expect(estat.memberCount).toBe(10);
+    }
+  });
+
+  it('retorna Closed quan s\'ha assolit endDate, independentment de l\'aprovació', () => {
+    const estatAprovada = computeProposalState({
+      now: ara,
+      startDate: ara - 2 * DIA,
+      endDate: ara - HORA,
+      approvalTally: { votesFor: 7, totalVotes: 7 },
+      memberCount: 10,
+    });
+    expect(estatAprovada.kind).toBe('Closed');
+
+    const estatRebutjada = computeProposalState({
+      now: ara,
+      startDate: ara - 2 * DIA,
+      endDate: ara - HORA,
+      approvalTally: { votesFor: 1, totalVotes: 5 },
+      memberCount: 10,
+    });
+    expect(estatRebutjada.kind).toBe('Closed');
+  });
+
+  it('retorna Open quan now === startDate exactament i aprovada', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara,
+      endDate: ara + DIA,
+      approvalTally: { votesFor: 7, totalVotes: 7 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('Open');
+  });
+
+  it('retorna Rejected quan now === startDate exactament i no aprovada', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara,
+      endDate: ara + DIA,
+      approvalTally: { votesFor: 1, totalVotes: 5 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('Rejected');
+  });
+
+  it('retorna Closed quan now === endDate exactament', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara - DIA,
+      endDate: ara,
+      approvalTally: { votesFor: 7, totalVotes: 7 },
+      memberCount: 10,
+    });
+    expect(estat.kind).toBe('Closed');
+  });
+
+  it('mai aprova amb zero membres', () => {
+    const estat = computeProposalState({
+      now: ara,
+      startDate: ara + DIA,
+      endDate: ara + 2 * DIA,
+      approvalTally: { votesFor: 0, totalVotes: 0 },
+      memberCount: 0,
+    });
+    expect(estat.kind).toBe('PendingApproval');
+  });
+});

--- a/client/src/domain/proposalState.ts
+++ b/client/src/domain/proposalState.ts
@@ -1,0 +1,45 @@
+import * as z from 'zod';
+
+const approvalTallySchema = z.object({
+  votesFor: z.number().int().nonnegative(),
+  totalVotes: z.number().int().nonnegative(),
+});
+
+export type ApprovalTally = z.infer<typeof approvalTallySchema>;
+
+export type ProposalStateKind =
+  | 'PendingApproval'
+  | 'Rejected'
+  | 'PendingStart'
+  | 'Open'
+  | 'Closed';
+
+export type ProposalState =
+  | { kind: 'PendingApproval'; approvalTally: ApprovalTally; memberCount: number }
+  | { kind: 'Rejected'; approvalTally: ApprovalTally; memberCount: number }
+  | { kind: 'PendingStart' }
+  | { kind: 'Open' }
+  | { kind: 'Closed' };
+
+export interface ProposalStateInputs {
+  now: number;
+  startDate: number;
+  endDate: number;
+  approvalTally: ApprovalTally;
+  memberCount: number;
+}
+
+export function isApproved(tally: ApprovalTally, memberCount: number): boolean {
+  return memberCount > 0 && 3 * tally.votesFor >= 2 * memberCount;
+}
+
+export function computeProposalState(inputs: ProposalStateInputs): ProposalState {
+  const { now, startDate, endDate, approvalTally, memberCount } = inputs;
+  const approved = isApproved(approvalTally, memberCount);
+
+  if (now >= endDate) return { kind: 'Closed' };
+  if (approved && now >= startDate) return { kind: 'Open' };
+  if (approved) return { kind: 'PendingStart' };
+  if (now >= startDate) return { kind: 'Rejected', approvalTally, memberCount };
+  return { kind: 'PendingApproval', approvalTally, memberCount };
+}

--- a/client/src/hooks/useAlgorand.ts
+++ b/client/src/hooks/useAlgorand.ts
@@ -1,3 +1,5 @@
+import {asAddress} from "@/domain";
+
 import { useWallet } from '@txnlab/use-wallet-react';
 import { algodClient } from '@/algorand/config';
 
@@ -6,7 +8,7 @@ export function useAlgorand() {
 
   return {
     isConnected: !!activeAddress,
-    address: activeAddress ?? null,
+    address: activeAddress ? asAddress(activeAddress) : null,
     signer: transactionSigner,
     algodClient,
     wallets,

--- a/client/src/hooks/useProposalDetail.ts
+++ b/client/src/hooks/useProposalDetail.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type {ProposalId} from "@/domain";
+
+import { proposalQueries, organizationQueries } from '@/algorand/queries';
+
+export function useProposalDetail(id: ProposalId) {
+  const proposalQuery = useQuery({
+    ...proposalQueries.detail(id)
+  });
+
+  const proposal = proposalQuery.data ?? null;
+  const orgId = proposal?.orgId;
+
+  const orgQuery = useQuery({
+    ...organizationQueries.detail(orgId!),
+    enabled: orgId !== undefined,
+  });
+
+  return {
+    proposal,
+    organization: orgQuery.data ?? null,
+    isPending: proposalQuery.isPending || (orgId !== undefined && orgQuery.isPending),
+    isError: proposalQuery.isError || orgQuery.isError,
+    error: proposalQuery.error ?? orgQuery.error,
+    refetch: proposalQuery.refetch,
+  };
+}

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -14,6 +14,7 @@
     "previous": "Anterior",
     "next": "Següent",
     "waiting": "Esperant...",
+    "retry": "Reintentar",
     "description": "Descripció",
     "census": "Cens",
     "addresses": "Adreces",
@@ -23,12 +24,14 @@
     "connect": "Connectar",
     "disconnect": "Desconnectar",
     "step": "Pas {{current}} de {{total}}",
+    "completeness": "{{current}} de {{total}}",
     "proposals": "Propostes",
     "org": "Organització",
     "basics": "Bàsics",
     "dates": "Dates",
     "options": "Opcions",
     "review": "Revisió",
+    "summary": "Resum",
     "member": "Membre",
     "members": "Membres",
     "organizer": "Organitzador",
@@ -208,7 +211,19 @@
         "title": "Proposta publicada!",
         "cta": "Veure la proposta"
       }
-    }
+    },
+    "approval": {
+      "reached": "S'ha assolit el llindar!"
+    },
+    "status": {
+      "pending": "Pendent d'aprovació",
+      "rejected": "Rebutjada",
+      "approved": "Aprovada",
+      "voting": "Votació oberta",
+      "closed": "Tancada"
+    },
+    "not-found": "Proposta no trobada.",
+    "options": "Opcions per ordenar"
   },
   "wallet": {
     "txid": "ID de transacció",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -14,6 +14,7 @@
     "previous": "Previous",
     "next": "Next",
     "waiting": "Waiting...",
+    "retry": "Retry",
     "description": "Description",
     "census": "Census",
     "addresses": "Addresses",
@@ -23,12 +24,14 @@
     "connect": "Connect",
     "disconnect": "Disconnect",
     "step": "Step {{current}} of {{total}}",
+    "completeness": "{{current}} of {{total}}",
     "proposals": "Proposals",
     "org": "Organization",
     "basics": "Basics",
     "dates": "Dates",
     "options": "Options",
     "review": "Review",
+    "summary": "Summary",
     "member": "Member",
     "members": "Members",
     "organizer": "Organizer",
@@ -208,7 +211,19 @@
         "title": "Proposal published!",
         "cta": "See the proposal"
       }
-    }
+    },
+    "approval": {
+      "reached": "The threshold has been reached!"
+    },
+    "status": {
+      "pending": "Pending approval",
+      "rejected": "Rejected",
+      "approved": "Approved",
+      "voting": "Voting open",
+      "closed": "Closed"
+    },
+    "not-found": "Proposal not found.",
+    "options": "Options to rank"
   },
   "wallet": {
     "txid": "Transaction ID",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -14,6 +14,7 @@
     "previous": "Anterior",
     "next": "Siguiente",
     "waiting": "Esperando...",
+    "retry": "Reintentar",
     "description": "Descripción",
     "census": "Censo",
     "addresses": "Direcciones",
@@ -23,12 +24,14 @@
     "connect": "Conectar",
     "disconnect": "Desconectar",
     "step": "Paso {{current}} de {{total}}",
+    "completeness": "{{current}} de {{total}}",
     "proposals": "Propuestas",
     "org": "Organización",
     "basics": "Básicos",
     "dates": "Fechas",
     "options": "Opciones",
     "review": "Revisión",
+    "summary": "Resumen",
     "member": "Miembro",
     "members": "Miembros",
     "organizer": "Organizador",
@@ -208,7 +211,19 @@
         "title": "¡Propuesta publicada!",
         "cta": "Ver la propuesta"
       }
-    }
+    },
+    "approval": {
+      "reached": "¡Se ha alcanzado el umbral!"
+    },
+    "status": {
+      "pending": "Pendiente de aprobación",
+      "rejected": "Rechazada",
+      "approved": "Aprobada",
+      "voting": "Votación abierta",
+      "closed": "Cerrada"
+    },
+    "not-found": "Propuesta no encontrada.",
+    "options": "Opciones para clasificar"
   },
   "wallet": {
     "txid": "ID de transacción",

--- a/client/src/pages/OrganizationDetailPage.tsx
+++ b/client/src/pages/OrganizationDetailPage.tsx
@@ -6,6 +6,8 @@ import {ArrowLeft, Lock} from 'lucide-react';
 
 import {useQuery} from '@tanstack/react-query';
 
+import type {OrganizationId} from "@/domain";
+
 import {organizationQueries} from '@/algorand/queries';
 
 import {useAlgorand} from '@/hooks/useAlgorand';
@@ -20,7 +22,7 @@ import {Drawer} from "@/components/ui/Drawer";
 type ActiveTab = 'proposals' | 'census';
 
 export function OrganizationDetailPage() {
-    const id = useLoaderData() as number
+    const id = useLoaderData() as OrganizationId
 
     const {t} = useTranslation();
     const navigate = useNavigate();

--- a/client/src/pages/ProposalDetailPage.tsx
+++ b/client/src/pages/ProposalDetailPage.tsx
@@ -1,0 +1,126 @@
+import {useTranslation} from 'react-i18next';
+import {Link, useLoaderData, useNavigate} from 'react-router-dom';
+import {ArrowLeft, CalendarDays, Building2, RefreshCw} from 'lucide-react';
+
+import type {ProposalId} from "@/domain";
+
+import {ApprovalBar} from '@/components/proposal/ApprovalBar';
+import {StatusBadge} from '@/components/proposal/StatusBadge';
+
+import {useProposalDetail} from '@/hooks/useProposalDetail';
+
+import {formatDatetime} from '@/utils/date';
+
+export function ProposalDetailPage() {
+    const id = useLoaderData() as ProposalId;
+
+    const {t, i18n} = useTranslation();
+    const locale = i18n.resolvedLanguage ?? 'en';
+    const navigate = useNavigate();
+
+    const {proposal, organization: org, isPending, error, refetch} = useProposalDetail(id);
+
+    if (isPending) {
+        return (
+            <div className="mx-auto max-w-4xl px-6 py-14">
+                <div className="mb-8 h-5 w-20 animate-pulse rounded-full bg-surface"/>
+                <div className="h-12 w-2/3 animate-pulse rounded-2xl bg-surface"/>
+                <div className="mt-10 grid gap-6 md:grid-cols-[1.5fr_1fr]">
+                    <div className="h-64 animate-pulse rounded-2xl bg-surface"/>
+                    <div className="h-64 animate-pulse rounded-2xl bg-surface"/>
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !proposal) {
+        return (
+            <div className="mx-auto max-w-3xl px-6 py-20 text-center">
+                <p className="mb-4 text-muted">{error?.message ?? t('proposal.not-found')}</p>
+                <button
+                    onClick={() => void refetch()}
+                    className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm text-muted transition hover:text-fg"
+                >
+                    <RefreshCw size={14}/> {t('common.retry')}
+                </button>
+            </div>
+        );
+    }
+
+    const stateKind = proposal.state.kind;
+
+    return (
+        <div className="mx-auto max-w-4xl px-6 py-14">
+            <button
+                onClick={() => navigate(-1)}
+                className="mb-8 inline-flex items-center gap-2 text-sm text-muted transition hover:text-fg"
+            >
+                <ArrowLeft size={16}/> {t('common.back')}
+            </button>
+
+            <div className="mb-4 flex flex-wrap items-center gap-3">
+                <StatusBadge status={stateKind}/>
+                {org && (
+                    <Link
+                        to={`/organizations/${org.id}`}
+                        className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-muted transition hover:border-primary hover:text-primary"
+                    >
+                        <Building2 size={11}/> {org.name}
+                    </Link>
+                )}
+            </div>
+
+            <h1 className="font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+                {proposal.title}
+            </h1>
+
+            <div className="mt-5 inline-flex items-center gap-2 text-sm text-muted">
+                <CalendarDays size={14}/>
+                {formatDatetime(proposal.startDate, locale)} → {formatDatetime(proposal.endDate, locale)}
+            </div>
+
+            <div className="mt-10 grid gap-6 md:grid-cols-[1.5fr_1fr]">
+                <div className="rounded-2xl border border-border bg-surface p-6">
+                    {proposal.description && (
+                        <>
+                            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted">
+                                {t('common.summary')}
+                            </h2>
+                            <p className="leading-relaxed text-fg">{proposal.description}</p>
+                        </>
+                    )}
+
+                    <h2 className="mb-3 mt-8 text-xs font-semibold uppercase tracking-wider text-muted">
+                        {t('proposal.options')}
+                    </h2>
+                    <ul className="space-y-2">
+                        {proposal.options.map((opt, i) => (
+                            <li
+                                key={opt.id}
+                                className="flex items-start gap-3 rounded-xl border border-border bg-elevated px-4 py-3"
+                            >
+                                <span
+                                    className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                                    {i + 1}
+                                </span>
+                                <div>
+                                    <div className="text-sm font-medium text-fg">{opt.title}</div>
+                                    {opt.description && <div className="text-xs text-muted">{opt.description}</div>}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                {/* Sidebar */}
+                <aside className="flex flex-col gap-5">
+                    <div className="rounded-2xl border border-border bg-surface p-6">
+                        <ApprovalBar yes={proposal.approvalTally.votesFor} total={proposal.memberCount}/>
+                    </div>
+
+                    TODO
+                </aside>
+            </div>
+        </div>
+    );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,7 +1,9 @@
 import {createBrowserRouter} from 'react-router-dom';
 
-import {queryClient} from "@/queryClient.ts";
-import {organizationQueries} from "@/algorand/queries";
+import {asOrganizationId, asProposalId} from "@/domain";
+
+import {organizationQueries, proposalQueries} from "@/algorand/queries";
+import {queryClient} from "@/queryClient";
 
 import {RouteError} from "@/components/RouteError";
 
@@ -14,6 +16,8 @@ import {NewOrganizationPage} from "@/pages/NewOrganizationPage";
 import {OrganizationDetailPage} from "@/pages/OrganizationDetailPage";
 
 import {NewProposalPage} from "@/pages/NewProposalPage";
+
+import {ProposalDetailPage} from "@/pages/ProposalDetailPage";
 
 import {parseRouteId} from "@/hooks/utils.ts";
 
@@ -37,7 +41,7 @@ export const router = createBrowserRouter([{
         {
             path: '/organizations/:id',
             loader: async ({params}) => {
-                const id = parseRouteId(params.id);
+                const id = asOrganizationId(parseRouteId(params['id']));
 
                 await Promise.all([
                     queryClient.ensureQueryData(organizationQueries.detail(id)),
@@ -52,6 +56,22 @@ export const router = createBrowserRouter([{
         {
             path: '/organizations/new',
             element: <NewOrganizationPage/>
+        },
+        {
+            path: '/proposals/:id',
+            loader: async ({ params }) => {
+                const id = asProposalId(parseRouteId(params['id']));
+
+                const proposal = await queryClient.ensureQueryData(proposalQueries.detail(id));
+
+                if (proposal) {
+                    void queryClient.ensureQueryData(organizationQueries.detail(proposal.orgId));
+                }
+
+                return id;
+            },
+            element: <ProposalDetailPage />,
+            errorElement: <RouteError />,
         },
         {
             path: '/proposals/new',


### PR DESCRIPTION
## Descripció del canvi

S'implementa la pàgina de detall de la proposta, que consulta i mostra l'estat actual de la proposta directament des del contracte d'Algorand. S'inclou també la lògica de connexió entre el contracte i el client (*queries*, *mutations* i mapeig de dades), i correccions menors en els *schemas* de domini d'organitzacions i propostes.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #319

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal