### PR TITLE
feat(client): panell d'aprovació i rebuig dins el detall de la proposta

### DIFF
--- a/client/src/algorand/_contract.ts
+++ b/client/src/algorand/_contract.ts
@@ -1,7 +1,10 @@
 import algosdk from 'algosdk';
 
-import arc56 from './GovernanceContract.arc56.json';
+import type { Address, OrganizationId, ProposalId} from "@/domain";
+
 import {algodClient, APP_ID} from './config';
+
+import arc56 from './GovernanceContract.arc56.json';
 
 // ── Descodificador d'errors ARC-56 ─────────────────────────────────────────────
 const _pcErrorMap = new Map<number, string>();
@@ -41,7 +44,7 @@ export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 //   approval_tallies: "at_"       (YXRf)             3 bytes + uint64 = 11 bytes
 
 
-export function orgBoxKey(id: number): Uint8Array {
+export function orgBoxKey(id: OrganizationId): Uint8Array {
     return new Uint8Array([...enc.encode('org_'), ...algosdk.bigIntToBytes(id, 8)]);
 }
 
@@ -53,7 +56,7 @@ export function orgNameIndexKey(name: string): Uint8Array {
 }
 
 // census key: cs_ (3) + org_id (8) + member pubkey (32) = 43 bytes
-export function censusBoxKey(orgId: number, member: string): Uint8Array {
+export function censusBoxKey(orgId: OrganizationId, member: Address): Uint8Array {
     return new Uint8Array([
         ...enc.encode('cs_'),
         ...algosdk.bigIntToBytes(orgId, 8),
@@ -61,11 +64,11 @@ export function censusBoxKey(orgId: number, member: string): Uint8Array {
     ]);
 }
 
-export function proposalBoxKey(id: number): Uint8Array {
+export function proposalBoxKey(id: ProposalId): Uint8Array {
     return new Uint8Array([...enc.encode('proposals'), ...algosdk.bigIntToBytes(id, 8)]);
 }
 
-export function tallyBoxKey(id: number): Uint8Array {
+export function tallyBoxKey(id: ProposalId): Uint8Array {
     return new Uint8Array([...enc.encode('at_'), ...algosdk.bigIntToBytes(id, 8)]);
 }
 

--- a/client/src/algorand/proposals.ts
+++ b/client/src/algorand/proposals.ts
@@ -1,53 +1,57 @@
 import algosdk from "algosdk";
 
-import {asOrganizationId} from "@/domain";
+import {asOrganizationId, asProposalId, type Address, type OrganizationId, type ProposalId} from "@/domain";
 
 import type {OnChainApprovalTally, OnChainProposal} from "./wire";
 import {algodClient, APP_ID} from './config';
 
 import {
-  proposalBoxKey,
-  tallyBoxKey,
-  orgBoxKey,
-  censusBoxKey,
-  createProposalMethod,
-  callMethod,
-  readGlobalUint64,
-  type TransactionSigner,
+    proposalBoxKey,
+    tallyBoxKey,
+    orgBoxKey,
+    censusBoxKey,
+    createProposalMethod,
+    callMethod,
+    readGlobalUint64,
+    type TransactionSigner,
+    enc,
+    bytesEqual,
 } from './_contract';
 
 export async function createProposal(
-  signer: TransactionSigner,
-  sender: string,
-  orgId: number,
-  title: string,
-  description: string,
-  options: string[],
-  startingDate: number,
-  endingDate: number,
-): Promise<{ proposalId: number; txId: string }> {
-  const currentProposalId = await readGlobalUint64('proposal_id');
-  const nextId = currentProposalId + 1;
+    signer: TransactionSigner,
+    sender: Address,
+    orgId: OrganizationId,
+    title: string,
+    description: string,
+    options: string[],
+    startingDate: number,
+    endingDate: number,
+): Promise<{ proposalId: ProposalId; txId: string }> {
+    const currentProposalId = asProposalId(await readGlobalUint64('proposal_id'));
+    const nextId = asProposalId(currentProposalId + 1);
 
-  // create_proposal calls _assert_in_census, so census box is required too.
-  const result = await callMethod(
-    signer,
-    sender,
-    createProposalMethod,
-    [BigInt(orgId), title, description, options, BigInt(startingDate), BigInt(endingDate)],
-    [
-      { appIndex: APP_ID, name: proposalBoxKey(nextId) },
-      { appIndex: APP_ID, name: tallyBoxKey(nextId) },
-      { appIndex: APP_ID, name: orgBoxKey(orgId) },
-      { appIndex: APP_ID, name: censusBoxKey(orgId, sender) },
-    ],
-  );
+    // create_proposal calls _assert_in_census, so census box is required too.
+    const result = await callMethod(
+        signer,
+        sender,
+        createProposalMethod,
+        [BigInt(orgId), title, description, options, BigInt(startingDate), BigInt(endingDate)],
+        [
+            {appIndex: APP_ID, name: proposalBoxKey(nextId)},
+            {appIndex: APP_ID, name: tallyBoxKey(nextId)},
+            {appIndex: APP_ID, name: orgBoxKey(orgId)},
+            {appIndex: APP_ID, name: censusBoxKey(orgId, sender)},
+        ],
+    );
 
-  const proposalId = Number(result.returnValue as bigint);
-  return { proposalId, txId: result.txID };
+    return {
+        proposalId: asProposalId(Number(result.returnValue as bigint)),
+        txId: result.txID
+    };
 }
 
-export async function getProposal(proposalId: number): Promise<OnChainProposal | null> {
+export async function getProposal(proposalId: ProposalId): Promise<OnChainProposal | null> {
     try {
         const box = await algodClient.getApplicationBoxByName(APP_ID, proposalBoxKey(proposalId)).do();
         return decodeProposal(box.value);
@@ -56,12 +60,34 @@ export async function getProposal(proposalId: number): Promise<OnChainProposal |
     }
 }
 
-export async function getApprovalTally(proposalId: number): Promise<OnChainApprovalTally | null> {
+export async function getApprovalTally(proposalId: ProposalId): Promise<OnChainApprovalTally | null> {
     try {
         const box = await algodClient.getApplicationBoxByName(APP_ID, tallyBoxKey(proposalId)).do();
         return decodeTally(box.value);
     } catch {
         return null;
+    }
+}
+
+export async function getAllProposalIds(): Promise<ProposalId[]> {
+    try {
+        const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
+        const proposalPrefix = enc.encode('proposals'); // 9 bytes
+        const ids: ProposalId[] = [];
+
+        for (const box of boxes) {
+            const name = box.name;
+            if (name.length === 17 && bytesEqual(name.slice(0, 9), proposalPrefix)) {
+                const id = Number(algosdk.bytesToBigInt(name.slice(9)));
+
+                if (id > 0)
+                    ids.push(asProposalId(id));
+            }
+        }
+
+        return ids.sort((a, b) => a - b);
+    } catch {
+        return [];
     }
 }
 

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -11,6 +11,7 @@ import {
 } from './organizations';
 
 import {
+    getAllProposalIds,
     getApprovalTally,
     getProposal
 } from "./proposals";
@@ -38,6 +39,10 @@ async function fetchCensusMembers(orgId: OrganizationId): Promise<string[]> {
     return getCensusMembers(orgId);
 }
 
+async function fetchIsInCensus(address: Address, orgId: OrganizationId): Promise<boolean> {
+    return isInCensusChain(address, orgId);
+}
+
 async function fetchUserOrganizations(address: Address): Promise<Organization[]> {
     const ids = await getAllOrganizationIds();
 
@@ -61,6 +66,13 @@ async function fetchProposal(id: ProposalId): Promise<Proposal | null> {
     return mapToProposal(id, onChain, tally as OnChainApprovalTally, memberCount);
 }
 
+async function fetchProposals(): Promise<Proposal[]> {
+    const ids = await getAllProposalIds();
+    const results = await Promise.all(ids.map(fetchProposal));
+
+    return results.filter((p): p is Proposal => p !== null);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -76,6 +88,10 @@ export const organizationQueries = {
         queryKey: queryKeys.organizations.census(id),
         queryFn: () => fetchCensusMembers(id),
     }),
+    isMember: (address: Address, orgId: OrganizationId) => queryOptions({
+        queryKey: queryKeys.organizations.isMember(address, orgId),
+        queryFn: () => fetchIsInCensus(address, orgId),
+    }),
     forUser: (address: Address) => queryOptions({
         queryKey: queryKeys.organizations.forUser(address),
         queryFn: () => fetchUserOrganizations(address),
@@ -83,6 +99,10 @@ export const organizationQueries = {
 };
 
 export const proposalQueries = {
+    all: () => queryOptions({
+        queryKey: queryKeys.proposals.all(),
+        queryFn: fetchProposals,
+    }),
     detail: (id: ProposalId) => queryOptions({
         queryKey: queryKeys.proposals.detail(id),
         queryFn: () => fetchProposal(id),

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
         all: () => ['organizations'] as const,
         detail: (id: OrganizationId) => ['organizations', id] as const,
         census: (id: OrganizationId) => ['organizations', id, 'census'] as const,
+        isMember: (address: Address, orgId: OrganizationId) => ['census', 'membership', orgId, address] as const,
         forUser: (address: Address) => ['organizations', 'user', address] as const,
     },
     // Prefix keys for broad namespace invalidation in mutations

--- a/client/src/components/organization/ProposalsTab.tsx
+++ b/client/src/components/organization/ProposalsTab.tsx
@@ -1,0 +1,106 @@
+import {Link} from 'react-router-dom';
+import {useState, useMemo} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Plus, Search, FileX2} from 'lucide-react';
+
+import type {Proposal} from '@/domain';
+
+import {ProposalCard} from '@/components/proposal/ProposalCard';
+
+type Filter = 'active' | 'all' | 'pending' | 'approved' | 'voting' | 'closed';
+
+const FILTERS: Filter[] = ['active', 'pending', 'approved', 'voting', 'closed', 'all'];
+
+function proposalMatchesFilter(p: Proposal, filter: Filter): boolean {
+    const filters: Record<Filter, boolean> = {
+        all: true,
+        active: p.state.kind !== 'Closed',
+        pending: p.state.kind === 'PendingApproval',
+        approved: p.state.kind === 'PendingStart',
+        voting: p.state.kind === 'Open',
+        closed: p.state.kind === 'Closed',
+    }
+
+    return filters[filter];
+}
+
+interface Props {
+    proposals: Proposal[];
+    canCreate: boolean;
+    newProposalHref: string;
+}
+
+export function ProposalsTab({proposals, canCreate, newProposalHref}: Props) {
+    const {t} = useTranslation();
+    const [filter, setFilter] = useState<Filter>('active');
+    const [query, setQuery] = useState('');
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase();
+
+        return proposals.filter(p => {
+            if (!proposalMatchesFilter(p, filter)) return false;
+            return !(q && !p.title.toLowerCase().includes(q));
+        });
+    }, [proposals, filter, query]);
+
+    if (proposals.length === 0) {
+        return (
+            <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-border p-12 text-center">
+                <FileX2 size={28} className="text-muted"/>
+                <p className="text-sm text-muted">{t('org.proposals.empty')}</p>
+                {canCreate && (
+                    <Link
+                        to={newProposalHref}
+                        className="inline-flex h-10 items-center gap-2 rounded-full bg-gradient-to-br from-primary to-accent px-4 text-xs font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+                    >
+                        <Plus size={13}/> {t('proposal.new.short-title')}
+                    </Link>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+                <div className="relative min-w-[220px] flex-1">
+                    <Search size={15} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted"/>
+                    <input
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder={t('org.proposals.search-placeholder')}
+                        className="h-10 w-full rounded-full border border-border bg-surface pl-11 pr-4 text-sm text-fg placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                    {FILTERS.map(f => (
+                        <button
+                            key={f}
+                            onClick={() => setFilter(f)}
+                            className={`h-9 rounded-full border px-3.5 text-xs font-medium transition ${
+                                filter === f
+                                    ? 'border-primary bg-primary/10 text-primary'
+                                    : 'border-border bg-surface text-muted hover:text-fg'
+                            }`}
+                        >
+                            {t(`proposal.filters.${f}`)}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {filtered.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-border p-10 text-center text-sm text-muted">
+                    {t('proposal.filters.no-match')}
+                </div>
+            ) : (
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {filtered.map((p) => (
+                        <ProposalCard key={p.id} proposal={p}/>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/proposal/ProposalCard.tsx
+++ b/client/src/components/proposal/ProposalCard.tsx
@@ -1,0 +1,66 @@
+import {Lock} from 'lucide-react';
+import {useTranslation} from 'react-i18next';
+import {Link, useNavigate} from 'react-router-dom';
+
+import {type Proposal, type OrganizationId, approvalPercentage} from '@/domain';
+
+import {formatDatetime} from '@/utils/date';
+
+import {ApprovalBar} from './ApprovalBar';
+import {StatusBadge} from './StatusBadge';
+
+interface Props {
+    proposal: Proposal;
+    orgName?: string;
+    orgId?: OrganizationId;
+    locked?: boolean;
+}
+
+export function ProposalCard({proposal, orgName, orgId, locked}: Props) {
+    const {t, i18n} = useTranslation();
+
+    const navigate = useNavigate();
+    const locale = i18n.resolvedLanguage ?? 'en';
+    const pct = approvalPercentage(proposal);
+
+    return (
+        <div
+            onClick={() => navigate(`/proposals/${proposal.id}`)}
+            role="link"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && navigate(`/proposals/${proposal.id}`)}
+            className={`group flex cursor-pointer flex-col rounded-2xl border border-border/70 bg-surface/80 p-6 transition hover:-translate-y-0.5 hover:border-primary/60 hover:shadow-glow ${locked ? 'opacity-60' : ''}`}
+        >
+            <div className="flex items-start justify-between gap-2">
+                <StatusBadge status={proposal.state.kind}/>
+                <div className="flex shrink-0 items-center gap-1.5">
+                    {locked && <Lock size={13} className="text-muted"/>}
+                    {orgName && orgId != null && (
+                        <Link
+                            to={`/organizations/${orgId}`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="rounded-full border border-border px-2 py-0.5 text-xs text-muted transition hover:border-primary hover:text-primary"
+                        >
+                            {orgName}
+                        </Link>
+                    )}
+                </div>
+            </div>
+
+            <h3 className="mt-4 font-display text-lg font-semibold text-fg group-hover:text-primary">
+                {proposal.title}
+            </h3>
+            <p className="mt-1.5 line-clamp-2 text-sm text-muted">{proposal.description}</p>
+
+            <div className="mt-5 flex items-center justify-between text-xs text-muted">
+                <span>{formatDatetime(proposal.endDate, locale)}</span>
+                <span className="tabular-nums">
+                    {pct}% · {t('proposal.card.options', {count: proposal.options.length})}
+                </span>
+            </div>
+            <div className="mt-2">
+                <ApprovalBar yes={proposal.approvalTally.votesFor} total={proposal.memberCount} compact/>
+            </div>
+        </div>
+    );
+}

--- a/client/src/components/proposal/ProposalStatePanels.tsx
+++ b/client/src/components/proposal/ProposalStatePanels.tsx
@@ -1,0 +1,141 @@
+import {Link} from 'react-router-dom';
+import {useTranslation} from 'react-i18next';
+import {Clock, Lock, ThumbsDown, ThumbsUp, Wallet} from 'lucide-react';
+
+import type {ProposalId} from "@/domain";
+
+import {formatDatetime} from '@/utils/date';
+
+interface PendingApprovalPanelProps {
+    alreadyVoted: boolean;
+    isConnected: boolean;
+    isMember: boolean;
+    voting: 'approve' | 'reject' | null;
+    mutationError: Error | null;
+    onVote: (approve: boolean) => void;
+}
+
+export function PendingApprovalPanel({
+                                         alreadyVoted,
+                                         isConnected,
+                                         isMember,
+                                         voting,
+                                         mutationError,
+                                         onVote,
+                                     }: PendingApprovalPanelProps) {
+    const {t} = useTranslation();
+
+    return (
+        <div className="rounded-2xl border border-border bg-surface p-5">
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted">
+                {t('proposal.approval.cta')}
+            </h3>
+
+            {alreadyVoted ? (
+                <p className="text-sm text-emerald-500">{t('vote.already-voted')} ✓</p>
+            ) : !isConnected ? (
+                <p className="flex items-center gap-1.5 text-sm text-muted">
+                    <Wallet size={14}/> {t('wallet.connect')}
+                </p>
+            ) : !isMember ? (
+                <p className="flex items-center gap-1.5 text-sm text-amber-600 dark:text-amber-400">
+                    <Lock size={14}/> {t('org.not-member')}
+                </p>
+            ) : (
+                <div className="flex gap-3">
+                    <button
+                        onClick={() => onVote(true)}
+                        disabled={!!voting}
+                        className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 py-2.5 text-sm font-semibold text-emerald-600 transition hover:bg-emerald-500/20 disabled:opacity-50 dark:text-emerald-400"
+                    >
+                        <ThumbsUp size={15}/>
+                        {voting === 'approve' ? '…' : t('common.approve')}
+                    </button>
+                    <button
+                        onClick={() => onVote(false)}
+                        disabled={!!voting}
+                        className="inline-flex flex-1 items-center justify-center gap-2 rounded-full border border-rose-500/40 bg-rose-500/10 py-2.5 text-sm font-semibold text-rose-600 transition hover:bg-rose-500/20 disabled:opacity-50 dark:text-rose-400"
+                    >
+                        <ThumbsDown size={15}/>
+                        {voting === 'reject' ? '…' : t('common.reject')}
+                    </button>
+                </div>
+            )}
+
+            {mutationError && (
+                <p className="mt-3 text-xs text-rose-500">
+                    {mutationError.message ?? 'Transaction failed.'}
+                </p>
+            )}
+        </div>
+    );
+}
+
+interface PendingStartPanelProps {
+    startDate: number;
+    locale: string;
+}
+
+export function PendingStartPanel({startDate, locale}: PendingStartPanelProps) {
+    const {t} = useTranslation();
+
+    return (
+        <div className="flex flex-1 flex-col justify-center rounded-2xl border border-primary/30 bg-primary/5 p-5">
+            <div className="mb-1.5 flex items-center gap-2 text-sm font-semibold text-primary">
+                <Clock size={15}/>
+                {t('proposal.waiting-to-start')}
+            </div>
+            <p className="text-sm text-muted">
+                {t('vote.opens-on', {date: formatDatetime(startDate, locale)})}
+            </p>
+        </div>
+    );
+}
+
+interface VoteCtaPanelProps {
+    proposalId: ProposalId;
+    stateKind: 'Open' | 'Closed';
+    hasElectionVoted: boolean;
+}
+
+export function VoteCtaPanel({proposalId, stateKind, hasElectionVoted}: VoteCtaPanelProps) {
+    const {t} = useTranslation();
+
+    const voteLabel = t(`vote.${stateKind === 'Open' ? 'cta' : 'results.cta'}`);
+    const voteTo = `/proposals/${proposalId}/${stateKind === 'Open' ? 'vote' : 'results'}`;
+
+    if (stateKind === 'Closed') {
+        return (
+            <>
+                <p className="text-sm text-muted">{t('vote.closed-notice')}</p>
+                <Link
+                    to={voteTo}
+                    className="inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-br from-primary to-accent px-6 text-sm font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+                >
+                    {voteLabel}
+                </Link>
+            </>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {hasElectionVoted ? (
+                <p className="text-sm text-emerald-500">{t('vote.already-voted')} ✓</p>
+            ) : (
+                <Link
+                    to={voteTo}
+                    className="inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-br from-primary to-accent px-6 text-sm font-semibold text-primary-fg shadow-glow transition hover:brightness-110"
+                >
+                    {voteLabel}
+                </Link>
+            )}
+            <Link
+                to={`/proposals/${proposalId}/results`}
+                className="inline-flex h-10 items-center justify-center rounded-full border border-border px-6 text-sm font-medium text-muted transition hover:text-fg"
+            >
+                {t('vote.results.cta')}
+            </Link>
+        </div>
+    );
+}

--- a/client/src/domain/proposal.ts
+++ b/client/src/domain/proposal.ts
@@ -43,3 +43,8 @@ export type Proposal = ProposalBase & {
   approvalTally: ApprovalTally;
   memberCount: number;
 };
+
+export function approvalPercentage(proposal: Proposal): number {
+  if (proposal.memberCount <= 0) return 0;
+  return Math.round((proposal.approvalTally.votesFor / proposal.memberCount) * 100);
+}

--- a/client/src/hooks/useProposalDetail.ts
+++ b/client/src/hooks/useProposalDetail.ts
@@ -3,8 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import type {ProposalId} from "@/domain";
 
 import { proposalQueries, organizationQueries } from '@/algorand/queries';
+import {useAlgorand} from "@/hooks/useAlgorand";
 
 export function useProposalDetail(id: ProposalId) {
+  const { address } = useAlgorand();
+
   const proposalQuery = useQuery({
     ...proposalQueries.detail(id)
   });
@@ -17,9 +20,17 @@ export function useProposalDetail(id: ProposalId) {
     enabled: orgId !== undefined,
   });
 
+  const isMemberQuery = useQuery({
+    ...organizationQueries.isMember(address!, orgId!),
+    enabled: address !== null && orgId !== undefined,
+  });
+
   return {
     proposal,
     organization: orgQuery.data ?? null,
+    isMember: isMemberQuery.data ?? false,
+    hasApprovalVoted: true /*TODO*/,
+    hasElectionVoted: true /*TODO*/,
     isPending: proposalQuery.isPending || (orgId !== undefined && orgQuery.isPending),
     isError: proposalQuery.isError || orgQuery.isError,
     error: proposalQuery.error ?? orgQuery.error,

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -10,6 +10,8 @@
     "title": "Títol",
     "cancel": "Cancel·la",
     "confirm": "Confirma",
+    "approve": "Aprovar",
+    "reject": "Rebutjar",
     "back": "Enrere",
     "previous": "Anterior",
     "next": "Següent",
@@ -43,7 +45,8 @@
     "start-date": "Data d'inici",
     "end-date": "Data de fi",
     "copied": "Copiat!",
-    "copy": "Copia"
+    "copy": "Copia",
+    "position": "Posició {{n}}"
   },
   "theme": {
     "toggle": "Canvia el tema",
@@ -136,6 +139,10 @@
     "not-member": "No ets membre d'aquesta organització",
     "not-member-short": "No membre",
     "show-all-members": "Veure tots els {{count}} membres",
+    "proposals": {
+      "empty": "Encara no hi ha propostes.",
+      "search-placeholder": "Cerca per títol…"
+    },
     "census": {
       "manage": "Gestiona el cens",
       "manage-hint": "Modifica els membres de «{{name}}».",
@@ -213,7 +220,18 @@
       }
     },
     "approval": {
+      "cta": "Votar per aprovar",
       "reached": "S'ha assolit el llindar!"
+    },
+    "filters": {
+      "status": "Estat",
+      "active": "Actives",
+      "all": "Totes",
+      "pending": "Pendent d'aprovació",
+      "approved": "Aprovada",
+      "voting": "Votació oberta",
+      "closed": "Tancada",
+      "no-match": "Cap proposta coincideix amb el filtre."
     },
     "status": {
       "pending": "Pendent d'aprovació",
@@ -222,8 +240,30 @@
       "voting": "Votació oberta",
       "closed": "Tancada"
     },
+    "card": {
+      "options": "{{count}} opció",
+      "options_other": "{{count}} opcions",
+      "runs": "Del {{start}} al {{end}}"
+    },
     "not-found": "Proposta no trobada.",
-    "options": "Opcions per ordenar"
+    "options": "Opcions per ordenar",
+    "waiting-to-start": "La votació obre aviat"
+  },
+  "vote": {
+    "title": "Ordena les teves preferències",
+    "subtitle": "Arrossega les opcions en el teu ordre de preferència. La primera tria va a dalt.",
+    "already-voted": "Ja has votat en aquesta elecció",
+    "already-voted-hint": "Cada adreça només pot votar una vegada. El teu vot ha quedat registrat a la cadena.",
+    "keyboard-hint": "Consell: prem Tab per enfocar una opció, després Espai + fletxes per moure-la.",
+    "submit": "Envia el teu vot",
+    "cta": "Emet el teu vot preferencial",
+    "confirmed": "Vot confirmat",
+    "ranking": "La teva classificació",
+    "results": {
+      "cta": "Mira els resultats"
+    },
+    "opens-on": "La finestra de votació s'obre el {{date}}. Torna llavors per emetre el teu vot.",
+    "closed-notice": "Aquesta elecció ha finalitzat."
   },
   "wallet": {
     "txid": "ID de transacció",
@@ -231,7 +271,9 @@
     "choose": "Estria wallet",
     "switch": "Canviar de compte",
     "address-filter-placeholder": "Filtrar per adreça…",
-    "waiting-signature": "Esperant signatura…"
+    "waiting-signature": "Esperant signatura…",
+    "view-on-lora": "Veure-ho a Lora",
+    "close-receipt": "Tancar rebut"
   },
   "errors": {
     "unknown": "Error desconegut",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -10,6 +10,8 @@
     "title": "Title",
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "approve": "Approve",
+    "reject": "Reject",
     "back": "Back",
     "previous": "Previous",
     "next": "Next",
@@ -43,7 +45,8 @@
     "start-date": "Start date",
     "end-date": "End Date",
     "copied": "Copied!",
-    "copy": "Copy"
+    "copy": "Copy",
+    "position": "Position {{n}}"
   },
   "theme": {
     "toggle": "Toggle theme",
@@ -136,6 +139,10 @@
     "not-member": "You are not a member of this organization",
     "not-member-short": "Non-member",
     "show-all-members": "See all {{count}} members",
+    "proposals": {
+      "empty": "No proposals yet.",
+      "search-placeholder": "Search by title…"
+    },
     "census": {
       "manage": "Manage census",
       "manage-hint": "Modify the members of \"{{name}}\".",
@@ -213,7 +220,18 @@
       }
     },
     "approval": {
+      "cta": "Vote to approve",
       "reached": "The threshold has been reached!"
+    },
+    "filters": {
+      "status": "Status",
+      "active": "Active",
+      "all": "All",
+      "pending": "Pending approval",
+      "approved": "Approved",
+      "voting": "Voting open",
+      "closed": "Closed",
+      "no-match": "No proposal matches the filter."
     },
     "status": {
       "pending": "Pending approval",
@@ -222,8 +240,30 @@
       "voting": "Voting open",
       "closed": "Closed"
     },
+    "card": {
+      "options": "{{count}} option",
+      "options_other": "{{count}} options",
+      "runs": "Runs {{start}} → {{end}}"
+    },
     "not-found": "Proposal not found.",
-    "options": "Options to rank"
+    "options": "Options to rank",
+    "waiting-to-start": "Voting opens soon"
+  },
+  "vote": {
+    "title": "Rank your preferences",
+    "subtitle": "Drag options into your order of preference. Your first choice goes on top.",
+    "already-voted": "You've already voted in this election",
+    "already-voted-hint": "Each address can only vote once. Your ballot has been recorded on-chain.",
+    "keyboard-hint": "Tip: use Tab to focus an option, then Space + arrow keys to move it.",
+    "submit": "Submit your vote",
+    "cta": "Cast your ranked vote",
+    "confirmed": "Vote confirmed",
+    "ranking": "Your ranking",
+    "results": {
+      "cta": "See results"
+    },
+    "opens-on": "The election window opens on {{date}}. Come back then to cast your vote.",
+    "closed-notice": "This election has concluded."
   },
   "wallet": {
     "txid": "Transaction ID",
@@ -231,7 +271,9 @@
     "choose": "Choose wallet",
     "switch": "Switch account",
     "address-filter-placeholder": "Filter by address…",
-    "waiting-signature": "Waiting signature…"
+    "waiting-signature": "Waiting signature…",
+    "view-on-lora": "View on Lora",
+    "close-receipt": "Close receipt"
   },
   "errors": {
     "unknown": "Unknown error",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -10,6 +10,8 @@
     "title": "Título",
     "cancel": "Cancelar",
     "confirm": "Confirma",
+    "approve": "Aprobar",
+    "reject": "Rechazar",
     "back": "Atrás",
     "previous": "Anterior",
     "next": "Siguiente",
@@ -43,7 +45,8 @@
     "start-date": "Fecha de inicio",
     "end-date": "Fecha de finalización",
     "copied": "¡Copiado!",
-    "copy": "Copia"
+    "copy": "Copia",
+    "position": "Posición {{n}}"
   },
   "theme": {
     "toggle": "Cambiar tema",
@@ -136,6 +139,10 @@
     "not-member": "No eres miembro de esta organización",
     "not-member-short": "No miembro",
     "show-all-members": "Ver todos los {{count}} miembros",
+    "proposals": {
+      "empty": "Todavía no hay propuestas.",
+      "search-placeholder": "Busca por título…"
+    },
     "census": {
       "manage": "Gestionar censo",
       "manage-hint": "Modifica los miembros de «{{name}}».",
@@ -213,7 +220,18 @@
       }
     },
     "approval": {
+      "cta": "Votar para aprobar",
       "reached": "¡Se ha alcanzado el umbral!"
+    },
+    "filters": {
+      "status": "Estado",
+      "active": "Activas",
+      "all": "Todas",
+      "pending": "Pendiente de aprobación",
+      "approved": "Aprobada",
+      "voting": "Votación abierta",
+      "closed": "Cerrada",
+      "no-match": "Ninguna propuesta coincide con el filtro."
     },
     "status": {
       "pending": "Pendiente de aprobación",
@@ -222,8 +240,30 @@
       "voting": "Votación abierta",
       "closed": "Cerrada"
     },
+    "card": {
+      "options": "{{count}} opción",
+      "options_other": "{{count}} opciones",
+      "runs": "Del {{start}} al {{end}}"
+    },
     "not-found": "Propuesta no encontrada.",
-    "options": "Opciones para clasificar"
+    "options": "Opciones para clasificar",
+    "waiting-to-start": "La votación abre pronto"
+  },
+  "vote": {
+    "title": "Ordena tus preferencias",
+    "subtitle": "Arrastra las opciones en tu orden de preferencia. Tu primera elección va arriba.",
+    "already-voted": "Ya has votado en esta elección",
+    "already-voted-hint": "Cada dirección solo puede votar una vez. Tu voto ha quedado registrado en la cadena.",
+    "keyboard-hint": "Consejo: usa Tab para enfocar una opción, luego Espacio + flechas para moverla.",
+    "confirmed": "Voto confirmado",
+    "submit": "Envía tu voto",
+    "cta": "Emite tu voto preferencial",
+    "ranking": "Tu clasificación",
+    "results": {
+      "cta": "Ver resultados"
+    },
+    "opens-on": "La ventana de votación abre el {{date}}. Vuelve entonces para emitir tu voto.",
+    "closed-notice": "Esta elección ha finalizado."
   },
   "wallet": {
     "txid": "ID de transacción",
@@ -231,7 +271,9 @@
     "choose": "Escoger wallet",
     "switch": "Cambiar de cuenta",
     "address-filter-placeholder": "Filtrar por dirección…",
-    "waiting-signature": "Esperando firma…"
+    "waiting-signature": "Esperando firma…",
+    "view-on-lora": "Ver en Lora",
+    "close-receipt": "Cerrar recibo"
   },
   "errors": {
     "unknown": "Error desconocido",

--- a/client/src/pages/OrganizationDetailPage.tsx
+++ b/client/src/pages/OrganizationDetailPage.tsx
@@ -1,5 +1,5 @@
 import {useLoaderData, useNavigate} from 'react-router-dom';
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 
 import {useTranslation} from 'react-i18next';
 import {ArrowLeft, Lock} from 'lucide-react';
@@ -8,12 +8,13 @@ import {useQuery} from '@tanstack/react-query';
 
 import type {OrganizationId} from "@/domain";
 
-import {organizationQueries} from '@/algorand/queries';
+import {organizationQueries, proposalQueries} from '@/algorand/queries';
 
 import {useAlgorand} from '@/hooks/useAlgorand';
 
 import {CensusManager, type CensusMode} from "@/components/organization/CensusManager";
 import {OrganizationHero} from '@/components/organization/OrganizationHero';
+import {ProposalsTab} from "@/components/organization/ProposalsTab";
 import {CensusTab} from '@/components/organization/CensusTab';
 
 import {Tabs, TabList, Tab, TabPanel} from '@/components/ui/Tabs';
@@ -36,6 +37,8 @@ export function OrganizationDetailPage() {
         ...organizationQueries.census(id)
     });
 
+    const {data: allProposals = []} = useQuery(proposalQueries.all());
+
     const organization = orgQuery.data ?? null;
     const censusMembers = censusQuery.data ?? [];
     const orgLoading = orgQuery.isPending;
@@ -44,6 +47,17 @@ export function OrganizationDetailPage() {
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [censusMode, setCensusMode] = useState<CensusMode>('add');
     const [removeSelected, setRemoveSelected] = useState<Set<string>>(new Set());
+
+    const orgProposals = useMemo(
+        () => (organization ? allProposals.filter(p => p.orgId === organization.id) : []),
+        [allProposals, organization],
+    );
+
+    const activeProposals = useMemo(
+        () =>
+            orgProposals.filter(p => p.state.kind === 'Open' || p.state.kind === 'PendingStart').length,
+        [orgProposals],
+    );
 
     function handleModeChange(m: CensusMode) {
         setCensusMode(m);
@@ -97,8 +111,8 @@ export function OrganizationDetailPage() {
 
     const stats = [
         {label: t('commom.members'), value: organization.memberCount, accent: true},
-        {label: t('common.proposals'), value: /*TODO*/-1},
-        {label: t('common.active', {count: 2}), value: /*TODO*/-1},
+        {label: t('common.proposals'), value: orgProposals.length},
+        {label: t('common.active', {count: 2}), value: activeProposals},
     ];
 
     return (
@@ -122,8 +136,7 @@ export function OrganizationDetailPage() {
             />
 
             {!isMember && !isOrganizer && (
-                <div
-                    className="mt-6 flex items-center gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-5 py-4 text-sm text-amber-600 dark:text-amber-400">
+                <div className="mt-6 flex items-center gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-5 py-4 text-sm text-amber-600 dark:text-amber-400">
                     <Lock size={16} className="shrink-0"/>
                     {t('org.not-member')}
                 </div>
@@ -135,7 +148,7 @@ export function OrganizationDetailPage() {
                         active={activeTab === 'proposals'}
                         onClick={() => setActiveTab('proposals')}
                         label={t('common.proposals')}
-                        count={/*TODO*/-1}
+                        count={orgProposals.length}
                     />
                     <Tab
                         active={activeTab === 'census'}
@@ -146,9 +159,11 @@ export function OrganizationDetailPage() {
                 </TabList>
 
                 <TabPanel active={activeTab === 'proposals'}>
-                    <>
-                        TODO
-                    </>
+                    <ProposalsTab
+                        proposals={orgProposals}
+                        canCreate={isMember || isOrganizer}
+                        newProposalHref={`/proposals/new?org=${organization.id}`}
+                    />
                 </TabPanel>
 
                 <TabPanel active={activeTab === 'census'}>

--- a/client/src/pages/ProposalDetailPage.tsx
+++ b/client/src/pages/ProposalDetailPage.tsx
@@ -1,13 +1,16 @@
+import {useState} from "react";
 import {useTranslation} from 'react-i18next';
 import {Link, useLoaderData, useNavigate} from 'react-router-dom';
 import {ArrowLeft, CalendarDays, Building2, RefreshCw} from 'lucide-react';
 
 import type {ProposalId} from "@/domain";
 
+import {PendingApprovalPanel, PendingStartPanel, VoteCtaPanel} from "@/components/proposal/ProposalStatePanels";
 import {ApprovalBar} from '@/components/proposal/ApprovalBar';
 import {StatusBadge} from '@/components/proposal/StatusBadge';
 
 import {useProposalDetail} from '@/hooks/useProposalDetail';
+import {useAlgorand} from "@/hooks/useAlgorand";
 
 import {formatDatetime} from '@/utils/date';
 
@@ -18,7 +21,27 @@ export function ProposalDetailPage() {
     const locale = i18n.resolvedLanguage ?? 'en';
     const navigate = useNavigate();
 
-    const {proposal, organization: org, isPending, error, refetch} = useProposalDetail(id);
+    const {
+        proposal,
+        organization: org,
+        isMember,
+        hasApprovalVoted,
+        hasElectionVoted,
+        isPending,
+        error,
+        refetch
+    } = useProposalDetail(id);
+
+    const {isConnected, address, signer} = useAlgorand();
+    const [voting, setVoting] = useState<'approve' | 'reject' | null>(null);
+
+    const handleApprovalVote = async (approve: boolean) => {
+        if (!isConnected || !address || !proposal) return;
+
+        setVoting(approve ? 'approve' : 'reject');
+
+        // TODO
+    };
 
     if (isPending) {
         return (
@@ -93,6 +116,7 @@ export function ProposalDetailPage() {
                     <h2 className="mb-3 mt-8 text-xs font-semibold uppercase tracking-wider text-muted">
                         {t('proposal.options')}
                     </h2>
+
                     <ul className="space-y-2">
                         {proposal.options.map((opt, i) => (
                             <li
@@ -118,7 +142,28 @@ export function ProposalDetailPage() {
                         <ApprovalBar yes={proposal.approvalTally.votesFor} total={proposal.memberCount}/>
                     </div>
 
-                    TODO
+                    {stateKind === 'PendingApproval' && (
+                        <PendingApprovalPanel
+                            alreadyVoted={hasApprovalVoted}
+                            isConnected={isConnected}
+                            isMember={isMember}
+                            voting={voting}
+                            mutationError={null/*TODO*/}
+                            onVote={handleApprovalVote}
+                        />
+                    )}
+
+                    {stateKind === 'PendingStart' && (
+                        <PendingStartPanel startDate={proposal.startDate} locale={locale}/>
+                    )}
+
+                    {(stateKind === 'Open' || stateKind === 'Closed') && (
+                        <VoteCtaPanel
+                            proposalId={proposal.id}
+                            stateKind={stateKind}
+                            hasElectionVoted={hasElectionVoted}
+                        />
+                    )}
                 </aside>
             </div>
         </div>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -16,7 +16,6 @@ import {NewOrganizationPage} from "@/pages/NewOrganizationPage";
 import {OrganizationDetailPage} from "@/pages/OrganizationDetailPage";
 
 import {NewProposalPage} from "@/pages/NewProposalPage";
-
 import {ProposalDetailPage} from "@/pages/ProposalDetailPage";
 
 import {parseRouteId} from "@/hooks/utils.ts";
@@ -59,7 +58,7 @@ export const router = createBrowserRouter([{
         },
         {
             path: '/proposals/:id',
-            loader: async ({ params }) => {
+            loader: async ({params}) => {
                 const id = asProposalId(parseRouteId(params['id']));
 
                 const proposal = await queryClient.ensureQueryData(proposalQueries.detail(id));
@@ -70,8 +69,8 @@ export const router = createBrowserRouter([{
 
                 return id;
             },
-            element: <ProposalDetailPage />,
-            errorElement: <RouteError />,
+            element: <ProposalDetailPage/>,
+            errorElement: <RouteError/>,
         },
         {
             path: '/proposals/new',


### PR DESCRIPTION
## Descripció del canvi

S'afegeix el panell d'acció dins la pàgina de detall de la proposta que permet a l'usuari aprovar o rebutjar una proposta directament. S'actualitza també la pàgina de detall d'organització per mostrar les propostes associades amb el nou `ProposalsTab`.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #320 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal