### PR TITLE
feat(client): connexió on-chain per aprovar i rebutjar propostes

### DIFF
--- a/client/src/algorand/_contract.ts
+++ b/client/src/algorand/_contract.ts
@@ -72,6 +72,14 @@ export function tallyBoxKey(id: ProposalId): Uint8Array {
     return new Uint8Array([...enc.encode('at_'), ...algosdk.bigIntToBytes(id, 8)]);
 }
 
+export function approvalBallotKey(sender: Address, proposalId: ProposalId): Uint8Array {
+    return new Uint8Array([
+        ...enc.encode('ab_'),
+        ...algosdk.decodeAddress(sender).publicKey,
+        ...algosdk.bigIntToBytes(proposalId, 8),
+    ]);
+}
+
 // ── Definicions dels mètodes ABI ───────────────────────────────────────────
 
 export const createOrganizationMethod = new algosdk.ABIMethod({
@@ -112,6 +120,15 @@ export const createProposalMethod = new algosdk.ABIMethod({
         { type: 'uint64', name: 'ending_date' },
     ],
     returns: { type: 'uint64' },
+});
+
+export const castProposalVoteMethod = new algosdk.ABIMethod({
+    name: 'cast_proposal_vote',
+    args: [
+        { type: 'uint64', name: 'proposal_id' },
+        { type: 'bool', name: 'approve' },
+    ],
+    returns: { type: 'void' },
 });
 
 // ── Executor ATC ─────────────────────────────────────────────────────

--- a/client/src/algorand/mutations.ts
+++ b/client/src/algorand/mutations.ts
@@ -2,8 +2,11 @@ import type algosdk from 'algosdk';
 
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
+import type {Address, OrganizationId, ProposalId} from "@/domain";
+
 import {createOrganization, addToCensus, removeFromCensus} from './organizations';
 import {createProposal} from "./proposals";
+import {castApprovalVote} from "./voting";
 
 import {queryKeys} from './queryKeys';
 
@@ -11,7 +14,7 @@ import {queryKeys} from './queryKeys';
 
 interface SignerArgs {
     signer: algosdk.TransactionSigner;
-    sender: string;
+    sender: Address;
 }
 
 interface CreateOrganizationArgs extends SignerArgs {
@@ -20,18 +23,24 @@ interface CreateOrganizationArgs extends SignerArgs {
 }
 
 interface CensusArgs extends SignerArgs {
-    orgId: number;
-    members: string[];
+    orgId: OrganizationId;
+    members: Address[];
     onProgress?: (done: number, total: number) => void;
 }
 
 interface CreateProposalArgs extends SignerArgs {
-    orgId: number;
+    orgId: OrganizationId;
     title: string;
     description: string;
     options: string[];
     startingDate: number;
     endingDate: number;
+}
+
+interface CastApprovalVoteArgs extends SignerArgs {
+    proposalId: ProposalId;
+    orgId: OrganizationId;
+    approve: boolean;
 }
 
 // ── Mutation hooks ───────────────────────────────────────────────────
@@ -86,6 +95,21 @@ export function useCreateProposal() {
         },
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() });
+        },
+    });
+}
+
+export function useCastApprovalVote() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ signer, sender, proposalId, orgId, approve }: CastApprovalVoteArgs) => {
+            return castApprovalVote(signer, sender, proposalId, orgId, approve)
+        },
+        onSuccess: (_txId, { proposalId, sender }) => {
+            void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.detail(proposalId) });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.voting.approvalVoted(sender, proposalId) });
         },
     });
 }

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -16,6 +16,10 @@ import {
     getProposal
 } from "./proposals";
 
+import {
+    hasApprovalVoted
+} from "./voting";
+
 import {mapToOrganization, mapToProposal} from './mappers';
 import type {OnChainApprovalTally} from "./wire";
 import {queryKeys} from './queryKeys';
@@ -73,6 +77,10 @@ async function fetchProposals(): Promise<Proposal[]> {
     return results.filter((p): p is Proposal => p !== null);
 }
 
+async function fetchHasApprovalVoted(address: Address, proposalId: ProposalId): Promise<boolean> {
+    return hasApprovalVoted(address, proposalId);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -108,3 +116,10 @@ export const proposalQueries = {
         queryFn: () => fetchProposal(id),
     }),
 };
+
+export const votingQueries = {
+    approvalVoted: (address: Address, proposalId: ProposalId) => queryOptions({
+        queryKey: queryKeys.voting.approvalVoted(address, proposalId),
+        queryFn: () => fetchHasApprovalVoted(address, proposalId),
+    })
+}

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -14,4 +14,7 @@ export const queryKeys = {
         all: () => ['proposals'] as const,
         detail: (id: ProposalId) => ['proposals', id] as const
     },
+    voting: {
+        approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const
+    }
 }

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -1,0 +1,43 @@
+import type {Address, OrganizationId, ProposalId} from "@/domain";
+
+import {APP_ID} from './config';
+
+import {
+    type TransactionSigner,
+    callMethod,
+    proposalBoxKey,
+    tallyBoxKey,
+    orgBoxKey,
+    censusBoxKey,
+    approvalBallotKey,
+    boxExists,
+    castProposalVoteMethod
+} from './_contract';
+
+export async function castApprovalVote(
+    signer: TransactionSigner,
+    sender: Address,
+    proposalId: ProposalId,
+    orgId: OrganizationId,
+    approve: boolean,
+): Promise<string> {
+    const result = await callMethod(
+        signer,
+        sender,
+        castProposalVoteMethod,
+        [BigInt(proposalId), approve],
+        [
+            {appIndex: APP_ID, name: proposalBoxKey(proposalId)},
+            {appIndex: APP_ID, name: tallyBoxKey(proposalId)},
+            {appIndex: APP_ID, name: approvalBallotKey(sender, proposalId)},
+            {appIndex: APP_ID, name: orgBoxKey(orgId)},
+            {appIndex: APP_ID, name: censusBoxKey(orgId, sender)},
+        ],
+    );
+
+    return result.txID;
+}
+
+export async function hasApprovalVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
+    return boxExists(approvalBallotKey(sender, proposalId));
+}

--- a/client/src/pages/ProposalDetailPage.tsx
+++ b/client/src/pages/ProposalDetailPage.tsx
@@ -12,6 +12,7 @@ import {StatusBadge} from '@/components/proposal/StatusBadge';
 import {useProposalDetail} from '@/hooks/useProposalDetail';
 import {useAlgorand} from "@/hooks/useAlgorand";
 
+import {useCastApprovalVote} from "@/algorand/mutations";
 import {formatDatetime} from '@/utils/date';
 
 export function ProposalDetailPage() {
@@ -26,13 +27,14 @@ export function ProposalDetailPage() {
         organization: org,
         isMember,
         hasApprovalVoted,
-        hasElectionVoted,
+        hasElectionVoted/*TODO*/,
         isPending,
         error,
         refetch
     } = useProposalDetail(id);
 
     const {isConnected, address, signer} = useAlgorand();
+    const approvalVoteMutation = useCastApprovalVote();
     const [voting, setVoting] = useState<'approve' | 'reject' | null>(null);
 
     const handleApprovalVote = async (approve: boolean) => {
@@ -40,7 +42,19 @@ export function ProposalDetailPage() {
 
         setVoting(approve ? 'approve' : 'reject');
 
-        // TODO
+        try {
+            await approvalVoteMutation.mutateAsync({
+                signer,
+                sender: address,
+                proposalId: proposal.id,
+                orgId: proposal.orgId,
+                approve,
+            });
+        } catch {
+            // Error is tracked by approvalVoteMutation.error
+        } finally {
+            setVoting(null);
+        }
     };
 
     if (isPending) {
@@ -144,11 +158,11 @@ export function ProposalDetailPage() {
 
                     {stateKind === 'PendingApproval' && (
                         <PendingApprovalPanel
-                            alreadyVoted={hasApprovalVoted}
+                            alreadyVoted={approvalVoteMutation.isSuccess || hasApprovalVoted}
                             isConnected={isConnected}
                             isMember={isMember}
                             voting={voting}
-                            mutationError={null/*TODO*/}
+                            mutationError={approvalVoteMutation.isError ? approvalVoteMutation.error : null}
                             onVote={handleApprovalVote}
                         />
                     )}


### PR DESCRIPTION
## Descripció del canvi

S'implementa la connexió entre el client i el contracte d'Algorand per enregistrar les accions d'aprovació i rebuig de propostes. S'afegeix el mòdul `voting.ts` amb les mutacions corresponents i s'integra a la pàgina de detall de la proposta per fer les crides *on-chain* en temps real.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #321 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
