### PR TITLE
feat(client): filtres i cerca de propostes per títol i descripció

### DIFF
--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -6,3 +6,5 @@ export * from './organizationDraft';
 export * from './proposal';
 export * from './proposalDraft';
 export * from './proposalState'
+
+export * from './proposalFilter'

--- a/client/src/domain/proposalFilter.test.ts
+++ b/client/src/domain/proposalFilter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'bun:test';
+import { proposalMatchesFilter } from './proposalFilter';
+import type { Proposal } from './proposal';
+import type { ProposalStateKind } from './proposalState';
+
+function mockProposal(stateKind: ProposalStateKind): Proposal {
+  const tally = { votesFor: 0, totalVotes: 0 };
+  const state =
+    stateKind === 'PendingApproval' ? { kind: 'PendingApproval' as const, approvalTally: tally, memberCount: 0 }
+    : stateKind === 'Rejected' ? { kind: 'Rejected' as const, approvalTally: tally, memberCount: 0 }
+    : stateKind === 'PendingStart' ? { kind: 'PendingStart' as const }
+    : stateKind === 'Open' ? { kind: 'Open' as const }
+    : { kind: 'Closed' as const };
+
+  return { state } as unknown as Proposal;
+}
+
+describe("filtre 'all'", () => {
+  const estats: ProposalStateKind[] = ['PendingApproval', 'PendingStart', 'Open', 'Rejected', 'Closed'];
+  for (const kind of estats) {
+    it(`retorna true per a ${kind}`, () => {
+      expect(proposalMatchesFilter(mockProposal(kind), 'all')).toBeTrue();
+    });
+  }
+});
+
+describe("filtre 'active'", () => {
+  it('retorna true per a PendingApproval', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingApproval'), 'active')).toBeTrue();
+  });
+
+  it('retorna true per a PendingStart', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingStart'), 'active')).toBeTrue();
+  });
+
+  it('retorna true per a Open', () => {
+    expect(proposalMatchesFilter(mockProposal('Open'), 'active')).toBeTrue();
+  });
+
+  it('retorna true per a Rejected (active = no Closed)', () => {
+    expect(proposalMatchesFilter(mockProposal('Rejected'), 'active')).toBeTrue();
+  });
+
+  it('retorna false només per a Closed', () => {
+    expect(proposalMatchesFilter(mockProposal('Closed'), 'active')).toBeFalse();
+  });
+});
+
+describe("filtre 'pending'", () => {
+  it('retorna true només per a PendingApproval', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingApproval'), 'pending')).toBeTrue();
+  });
+
+  it('retorna false per a PendingStart', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingStart'), 'pending')).toBeFalse();
+  });
+
+  it('retorna false per a Open', () => {
+    expect(proposalMatchesFilter(mockProposal('Open'), 'pending')).toBeFalse();
+  });
+
+  it('retorna false per a Rejected', () => {
+    expect(proposalMatchesFilter(mockProposal('Rejected'), 'pending')).toBeFalse();
+  });
+
+  it('retorna false per a Closed', () => {
+    expect(proposalMatchesFilter(mockProposal('Closed'), 'pending')).toBeFalse();
+  });
+});
+
+describe("filtre 'approved'", () => {
+  it('retorna true només per a PendingStart', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingStart'), 'approved')).toBeTrue();
+  });
+
+  it('retorna false per a PendingApproval', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingApproval'), 'approved')).toBeFalse();
+  });
+
+  it('retorna false per a Open', () => {
+    expect(proposalMatchesFilter(mockProposal('Open'), 'approved')).toBeFalse();
+  });
+
+  it('retorna false per a Rejected', () => {
+    expect(proposalMatchesFilter(mockProposal('Rejected'), 'approved')).toBeFalse();
+  });
+
+  it('retorna false per a Closed', () => {
+    expect(proposalMatchesFilter(mockProposal('Closed'), 'approved')).toBeFalse();
+  });
+});
+
+describe("filtre 'voting'", () => {
+  it('retorna true només per a Open', () => {
+    expect(proposalMatchesFilter(mockProposal('Open'), 'voting')).toBeTrue();
+  });
+
+  it('retorna false per a PendingApproval', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingApproval'), 'voting')).toBeFalse();
+  });
+
+  it('retorna false per a PendingStart', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingStart'), 'voting')).toBeFalse();
+  });
+
+  it('retorna false per a Rejected', () => {
+    expect(proposalMatchesFilter(mockProposal('Rejected'), 'voting')).toBeFalse();
+  });
+
+  it('retorna false per a Closed', () => {
+    expect(proposalMatchesFilter(mockProposal('Closed'), 'voting')).toBeFalse();
+  });
+});
+
+describe("filtre 'closed'", () => {
+  it('retorna true només per a Closed', () => {
+    expect(proposalMatchesFilter(mockProposal('Closed'), 'closed')).toBeTrue();
+  });
+
+  it('retorna false per a PendingApproval', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingApproval'), 'closed')).toBeFalse();
+  });
+
+  it('retorna false per a PendingStart', () => {
+    expect(proposalMatchesFilter(mockProposal('PendingStart'), 'closed')).toBeFalse();
+  });
+
+  it('retorna false per a Open', () => {
+    expect(proposalMatchesFilter(mockProposal('Open'), 'closed')).toBeFalse();
+  });
+
+  it('retorna false per a Rejected', () => {
+    expect(proposalMatchesFilter(mockProposal('Rejected'), 'closed')).toBeFalse();
+  });
+});

--- a/client/src/domain/proposalFilter.ts
+++ b/client/src/domain/proposalFilter.ts
@@ -1,0 +1,17 @@
+import type { Proposal } from './proposal';
+
+export type ProposalFilter = 'active' | 'all' | 'pending' | 'approved' | 'voting' | 'closed';
+
+export const PROPOSAL_FILTERS: ProposalFilter[] = [
+  'active', 'pending', 'approved', 'voting', 'closed', 'all',
+];
+
+export function proposalMatchesFilter(p: Proposal, filter: ProposalFilter): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'active') return p.state.kind !== 'Closed';
+  if (filter === 'pending') return p.state.kind === 'PendingApproval';
+  if (filter === 'approved') return p.state.kind === 'PendingStart';
+  if (filter === 'voting') return p.state.kind === 'Open';
+  if (filter === 'closed') return p.state.kind === 'Closed';
+  return true;
+}

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -8,6 +8,7 @@
   },
   "common": {
     "title": "Títol",
+    "search": "Cerca",
     "cancel": "Cancel·la",
     "confirm": "Confirma",
     "approve": "Aprovar",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -8,6 +8,7 @@
   },
   "common": {
     "title": "Title",
+    "search": "Search",
     "cancel": "Cancel",
     "confirm": "Confirm",
     "approve": "Approve",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -8,6 +8,7 @@
   },
   "common": {
     "title": "Título",
+    "search": "Buscar",
     "cancel": "Cancelar",
     "confirm": "Confirma",
     "approve": "Aprobar",

--- a/client/src/pages/ProposalsPage.tsx
+++ b/client/src/pages/ProposalsPage.tsx
@@ -1,11 +1,12 @@
-import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
+import {useState, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Plus, RefreshCw, Lock} from 'lucide-react';
+import {Plus, RefreshCw, Lock, Search} from 'lucide-react';
 
 import {useQuery} from '@tanstack/react-query';
 
-import type {Proposal, Organization, OrganizationId} from '@/domain';
+import type {Proposal, Organization, OrganizationId, ProposalFilter} from '@/domain';
+import {PROPOSAL_FILTERS, proposalMatchesFilter} from '@/domain';
 
 import {ProposalCard} from '@/components/proposal/ProposalCard';
 
@@ -41,6 +42,9 @@ export function ProposalsPage() {
 
     const {address, isConnected} = useAlgorand();
 
+    const [filter, setFilter] = useState<ProposalFilter>('active');
+    const [query, setQuery] = useState('');
+
     const {data: proposals = [], isPending, error, refetch} = useQuery(proposalQueries.all());
     const {data: organizations = []} = useQuery(organizationQueries.all());
     const {data: userOrganizations = []} = useQuery({
@@ -58,13 +62,24 @@ export function ProposalsPage() {
         [userOrganizations]
     );
 
+    const applyFilters = (list: Proposal[]) => {
+        return list.filter(p => {
+            if (!proposalMatchesFilter(p, filter)) return false;
+
+            return !query || (
+                p.title.toLowerCase().includes(query.toLowerCase()) ||
+                p.description.toLowerCase().includes(query.toLowerCase())
+            );
+        });
+    }
+
     const myProposals = isConnected
-        ? proposals.filter(p => userOrgIds.has(p.orgId))
+        ? applyFilters(proposals.filter(p => userOrgIds.has(p.orgId)))
         : [];
 
     const otherProposals = isConnected
-        ? proposals.filter(p => !userOrgIds.has(p.orgId))
-        : proposals;
+        ? applyFilters(proposals.filter(p => !userOrgIds.has(p.orgId)))
+        : applyFilters(proposals);
 
     return (
         <div className="mx-auto max-w-7xl px-6 py-14">
@@ -82,6 +97,33 @@ export function ProposalsPage() {
                     <Plus size={16}/>
                     {t('proposal.new.short-title')}
                 </Link>
+            </div>
+
+            <div className="mb-10 flex flex-wrap items-center gap-3">
+                <div className="relative min-w-[240px] flex-1">
+                    <Search size={16} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted"/>
+                    <input
+                        value={query}
+                        onChange={e => setQuery(e.target.value)}
+                        placeholder={t('common.search')}
+                        className="h-11 w-full rounded-full border border-border bg-surface pl-11 pr-4 text-sm text-fg placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    {PROPOSAL_FILTERS.map(f => (
+                        <button
+                            key={f}
+                            onClick={() => setFilter(f)}
+                            className={`h-10 rounded-full border px-4 text-sm font-medium transition ${
+                                filter === f
+                                    ? 'border-primary bg-primary text-primary-fg'
+                                    : 'border-border bg-surface text-muted hover:text-fg'
+                            }`}
+                        >
+                            {t(`proposal.filters.${f}`)}
+                        </button>
+                    ))}
+                </div>
             </div>
 
             {isPending && (


### PR DESCRIPTION
## Descripció del canvi

S'afegeix funcionalitat de filtratge i cerca a la pàgina de llistat de propostes, permetent a l'usuari cercar per títol i descripció. La lògica de filtratge s'implementa al domini (`proposalFilter.ts`) amb els tests corresponents, mantenint la UI desacoblada de la lògica de negoci.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #325 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal