### PR TITLE
feat(client): lògica d'enviament del vot al contracte

### DIFF
--- a/client/src/algorand/_contract.ts
+++ b/client/src/algorand/_contract.ts
@@ -80,6 +80,14 @@ export function approvalBallotKey(sender: Address, proposalId: ProposalId): Uint
     ]);
 }
 
+export function electionBallotKey(sender: Address, proposalId: ProposalId): Uint8Array {
+    return new Uint8Array([
+        ...enc.encode('eb_'),
+        ...algosdk.decodeAddress(sender).publicKey,
+        ...algosdk.bigIntToBytes(proposalId, 8),
+    ]);
+}
+
 // ── Definicions dels mètodes ABI ───────────────────────────────────────────
 
 export const createOrganizationMethod = new algosdk.ABIMethod({
@@ -127,6 +135,15 @@ export const castProposalVoteMethod = new algosdk.ABIMethod({
     args: [
         { type: 'uint64', name: 'proposal_id' },
         { type: 'bool', name: 'approve' },
+    ],
+    returns: { type: 'void' },
+});
+
+export const castElectionVoteMethod = new algosdk.ABIMethod({
+    name: 'cast_election_vote',
+    args: [
+        { type: 'uint64', name: 'proposal_id' },
+        { type: 'uint8[]', name: 'preference_order' },
     ],
     returns: { type: 'void' },
 });

--- a/client/src/algorand/mutations.ts
+++ b/client/src/algorand/mutations.ts
@@ -5,8 +5,8 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import type {Address, OrganizationId, ProposalId} from "@/domain";
 
 import {createOrganization, addToCensus, removeFromCensus} from './organizations';
+import {castApprovalVote, castRankedVote} from "./voting";
 import {createProposal} from "./proposals";
-import {castApprovalVote} from "./voting";
 
 import {queryKeys} from './queryKeys';
 
@@ -41,6 +41,12 @@ interface CastApprovalVoteArgs extends SignerArgs {
     proposalId: ProposalId;
     orgId: OrganizationId;
     approve: boolean;
+}
+
+interface CastRankedVoteArgs extends SignerArgs {
+    proposalId: ProposalId;
+    orgId: OrganizationId;
+    preferenceOrder: number[];
 }
 
 // ── Mutation hooks ───────────────────────────────────────────────────
@@ -110,6 +116,20 @@ export function useCastApprovalVote() {
             void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.detail(proposalId) });
             void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() });
             void queryClient.invalidateQueries({ queryKey: queryKeys.voting.approvalVoted(sender, proposalId) });
+        },
+    });
+}
+
+export function useCastRankedVote() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ signer, sender, proposalId, orgId, preferenceOrder }: CastRankedVoteArgs) => {
+            return castRankedVote(signer, sender, proposalId, orgId, preferenceOrder)
+        },
+        onSuccess: (_txId, { proposalId, sender }) => {
+            void queryClient.invalidateQueries({ queryKey: queryKeys.voting.electionVoted(sender, proposalId) });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.electionPrefix });
         },
     });
 }

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -17,7 +17,8 @@ import {
 } from "./proposals";
 
 import {
-    hasApprovalVoted
+    hasApprovalVoted,
+    hasElectionVoted
 } from "./voting";
 
 import {mapToOrganization, mapToProposal} from './mappers';
@@ -81,6 +82,10 @@ async function fetchHasApprovalVoted(address: Address, proposalId: ProposalId): 
     return hasApprovalVoted(address, proposalId);
 }
 
+async function fetchHasElectionVoted(address: Address, proposalId: ProposalId): Promise<boolean> {
+    return hasElectionVoted(address, proposalId);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -121,5 +126,9 @@ export const votingQueries = {
     approvalVoted: (address: Address, proposalId: ProposalId) => queryOptions({
         queryKey: queryKeys.voting.approvalVoted(address, proposalId),
         queryFn: () => fetchHasApprovalVoted(address, proposalId),
-    })
+    }),
+    electionVoted: (address: Address, proposalId: ProposalId) => queryOptions({
+        queryKey: queryKeys.voting.electionVoted(address, proposalId),
+        queryFn: () => fetchHasElectionVoted(address, proposalId),
+    }),
 }

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -15,6 +15,8 @@ export const queryKeys = {
         detail: (id: ProposalId) => ['proposals', id] as const
     },
     voting: {
-        approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const
-    }
+        approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const,
+        electionVoted: (address: Address, proposalId: ProposalId) => ['voting', 'election', address, proposalId] as const
+    },
+    electionPrefix: ['election'] as const
 }

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -10,8 +10,10 @@ import {
     orgBoxKey,
     censusBoxKey,
     approvalBallotKey,
+    electionBallotKey,
     boxExists,
-    castProposalVoteMethod
+    castProposalVoteMethod,
+    castElectionVoteMethod
 } from './_contract';
 
 export async function castApprovalVote(
@@ -38,6 +40,34 @@ export async function castApprovalVote(
     return result.txID;
 }
 
+export async function castRankedVote(
+    signer: TransactionSigner,
+    sender: Address,
+    proposalId: ProposalId,
+    orgId: OrganizationId,
+    preferenceOrder: number[],
+): Promise<string> {
+    const result = await callMethod(
+        signer,
+        sender,
+        castElectionVoteMethod,
+        [BigInt(proposalId), preferenceOrder.map((n) => BigInt(n))],
+        [
+            {appIndex: APP_ID, name: proposalBoxKey(proposalId)},
+            {appIndex: APP_ID, name: tallyBoxKey(proposalId)},
+            {appIndex: APP_ID, name: electionBallotKey(sender, proposalId)},
+            {appIndex: APP_ID, name: orgBoxKey(orgId)},
+            {appIndex: APP_ID, name: censusBoxKey(orgId, sender)},
+        ],
+    );
+
+    return result.txID;
+}
+
 export async function hasApprovalVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
     return boxExists(approvalBallotKey(sender, proposalId));
+}
+
+export async function hasElectionVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
+    return boxExists(electionBallotKey(sender, proposalId));
 }

--- a/client/src/hooks/useProposalDetail.ts
+++ b/client/src/hooks/useProposalDetail.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type {ProposalId} from "@/domain";
 
-import { proposalQueries, organizationQueries } from '@/algorand/queries';
+import { proposalQueries, organizationQueries, votingQueries } from '@/algorand/queries';
 import {useAlgorand} from "@/hooks/useAlgorand";
 
 export function useProposalDetail(id: ProposalId) {
@@ -25,12 +25,22 @@ export function useProposalDetail(id: ProposalId) {
     enabled: address !== null && orgId !== undefined,
   });
 
+  const approvalVotedQuery = useQuery({
+    ...votingQueries.approvalVoted(address!, id),
+    enabled: address !== null,
+  });
+
+  const electionVotedQuery = useQuery({
+    ...votingQueries.electionVoted(address!, id),
+    enabled: address !== null
+  });
+
   return {
     proposal,
     organization: orgQuery.data ?? null,
     isMember: isMemberQuery.data ?? false,
-    hasApprovalVoted: true /*TODO*/,
-    hasElectionVoted: true /*TODO*/,
+    hasApprovalVoted: approvalVotedQuery.data ?? false,
+    hasElectionVoted: electionVotedQuery.data ?? false,
     isPending: proposalQuery.isPending || (orgId !== undefined && orgQuery.isPending),
     isError: proposalQuery.isError || orgQuery.isError,
     error: proposalQuery.error ?? orgQuery.error,

--- a/client/src/pages/ProposalDetailPage.tsx
+++ b/client/src/pages/ProposalDetailPage.tsx
@@ -27,7 +27,7 @@ export function ProposalDetailPage() {
         organization: org,
         isMember,
         hasApprovalVoted,
-        hasElectionVoted/*TODO*/,
+        hasElectionVoted,
         isPending,
         error,
         refetch

--- a/client/src/pages/VotePage.tsx
+++ b/client/src/pages/VotePage.tsx
@@ -12,7 +12,9 @@ import {VoteReceipt} from '@/components/vote/VoteReceipt';
 
 import {Button} from '@/components/ui/Button';
 
-import {proposalQueries} from '@/algorand/queries';
+import {organizationQueries, proposalQueries, votingQueries} from '@/algorand/queries';
+import {useCastRankedVote} from '@/algorand/mutations';
+
 import {useAlgorand} from '@/hooks/useAlgorand';
 
 export function VotePage() {
@@ -26,8 +28,17 @@ export function VotePage() {
         ...proposalQueries.detail(id)
     });
 
-    const {data: hasVoted = false} = {/*TODO*/}
-    const {data: isMember = true} = {/*TODO*/}
+    const {data: hasVoted = false} = useQuery({
+        ...votingQueries.electionVoted(address!, id),
+        enabled: address !== null
+    });
+
+    const {data: isMember = false} = useQuery({
+        ...organizationQueries.isMember(address!, proposal?.orgId!),
+        enabled: address !== null && proposal?.orgId !== undefined,
+    });
+
+    const castVoteMutation = useCastRankedVote();
 
     const [options, setOptions] = useState<ProposalOption[]>([]);
     const [receipt, setReceipt] = useState<{ txId: string; ranking: ProposalOption[] } | null>(null);
@@ -60,7 +71,18 @@ export function VotePage() {
 
     const handleSubmit = async () => {
         if (!isConnected || !address) return;
-        // TODO
+
+        const preferenceOrder = options.map(o => o.id);
+
+        try {
+            const txId = await castVoteMutation.mutateAsync({
+                signer, sender: address, proposalId: proposal.id, orgId: proposal.orgId, preferenceOrder
+            });
+
+            setReceipt({txId, ranking: options});
+        } catch {
+            // Error is tracked by castVoteMutation.error
+        }
     };
 
     return (
@@ -104,8 +126,7 @@ export function VotePage() {
                 </div>
             ) : (
                 <>
-                    <div
-                        className="mt-5 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-xs text-muted">
+                    <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-xs text-muted">
                         <Keyboard size={14}/> {t('vote.keyboard-hint')}
                     </div>
 
@@ -113,14 +134,20 @@ export function VotePage() {
                         <RankingList options={options} onChange={setOptions}/>
                     </div>
 
+                    {castVoteMutation.isError && (
+                        <p className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-500">
+                            {castVoteMutation.error instanceof Error ? castVoteMutation.error.message : 'Transaction failed. Please try again.'}
+                        </p>
+                    )}
+
                     <div className="mt-10 flex items-center justify-end gap-3">
                         {!isConnected && (
                             <span className="flex items-center gap-1.5 text-sm text-muted">
                                 <Wallet size={14}/> {t('wallet.connect')}
                             </span>
                         )}
-                        <Button size="lg" onClick={handleSubmit} disabled={!isConnected}>
-                            {t('vote.submit')}
+                        <Button size="lg" onClick={handleSubmit} disabled={!isConnected || castVoteMutation.isPending}>
+                            {t(castVoteMutation.isPending ? 'wallet.waiting-signature': 'vote.submit')}
                         </Button>
                     </div>
                 </>


### PR DESCRIPTION
## Descripció del canvi

S'implementa la lògica d'enviament del vot des de la pàgina de votació cap al contracte d'Algorand. S'amplien les mutacions i queries existents per gestionar l'acció de votar, i s'integra el flux complet a `VotePage` i `useProposalDetail` perquè l'usuari pugui emetre el seu vot *on-chain*.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #334 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal