### PR TITLE
feat(client): pàgina de resultats amb seguiment de participació en temps real

### DIFF
--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -18,7 +18,8 @@ import {
 
 import {
     hasApprovalVoted,
-    hasElectionVoted
+    hasElectionVoted,
+    getElectionVoterCount
 } from "./voting";
 
 import {mapToOrganization, mapToProposal} from './mappers';
@@ -86,6 +87,10 @@ async function fetchHasElectionVoted(address: Address, proposalId: ProposalId): 
     return hasElectionVoted(address, proposalId);
 }
 
+async function fetchElectionVoterCount(proposalId: ProposalId): Promise<number> {
+    return getElectionVoterCount(proposalId);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -130,5 +135,9 @@ export const votingQueries = {
     electionVoted: (address: Address, proposalId: ProposalId) => queryOptions({
         queryKey: queryKeys.voting.electionVoted(address, proposalId),
         queryFn: () => fetchHasElectionVoted(address, proposalId),
+    }),
+    electionVoterCount: (proposalId: ProposalId) => queryOptions({
+        queryKey: queryKeys.voting.electionVoterCount(proposalId),
+        queryFn: () => fetchElectionVoterCount(proposalId),
     }),
 }

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -16,7 +16,8 @@ export const queryKeys = {
     },
     voting: {
         approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const,
-        electionVoted: (address: Address, proposalId: ProposalId) => ['voting', 'election', address, proposalId] as const
+        electionVoted: (address: Address, proposalId: ProposalId) => ['voting', 'election', address, proposalId] as const,
+        electionVoterCount: (proposalId: ProposalId) => ['election', 'voterCount', proposalId] as const,
     },
     electionPrefix: ['election'] as const
 }

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -1,6 +1,8 @@
+import algosdk from "algosdk";
+
 import type {Address, OrganizationId, ProposalId} from "@/domain";
 
-import {APP_ID} from './config';
+import {algodClient, APP_ID} from './config';
 
 import {
     type TransactionSigner,
@@ -12,6 +14,8 @@ import {
     approvalBallotKey,
     electionBallotKey,
     boxExists,
+    bytesEqual,
+    enc,
     castProposalVoteMethod,
     castElectionVoteMethod
 } from './_contract';
@@ -62,6 +66,24 @@ export async function castRankedVote(
     );
 
     return result.txID;
+}
+
+export async function getElectionVoterCount(proposalId: ProposalId): Promise<number> {
+    try {
+        const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
+        const prefix = enc.encode('eb_');
+        const pidBytes = algosdk.bigIntToBytes(proposalId, 8);
+
+        return boxes.filter(
+            (b) =>
+                b.name.length === 43 &&
+                bytesEqual(b.name.slice(0, 3), prefix) &&
+                bytesEqual(b.name.slice(35), pidBytes),
+        ).length;
+
+    } catch {
+        return 0;
+    }
 }
 
 export async function hasApprovalVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {

--- a/client/src/components/results/VerificationPanel.tsx
+++ b/client/src/components/results/VerificationPanel.tsx
@@ -1,0 +1,62 @@
+import {useState} from 'react';
+import {m} from 'framer-motion';
+import {useTranslation} from 'react-i18next';
+import {ShieldCheck, BadgeCheck} from 'lucide-react';
+
+import {Button} from '@/components/ui/Button';
+
+export function VerificationPanel() {
+    const {t} = useTranslation();
+
+    const [value, setValue] = useState('');
+    const [verified, setVerified] = useState(false);
+
+    return (
+        <div className="mt-14 rounded-3xl border border-border bg-elevated p-6">
+            <div className="mb-2 flex items-center gap-2">
+                <ShieldCheck size={18} className="text-primary"/>
+                <h3 className="font-display text-lg font-semibold text-fg">
+                    {t('results.verify.title')}
+                </h3>
+            </div>
+
+            <p className="mb-4 text-sm text-muted">
+                {t('results.verify.text')}
+            </p>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+                <input
+                    value={value}
+                    onChange={(e) => {
+                        setValue(e.target.value);
+                        setVerified(false);
+                    }}
+                    placeholder={t('results.verify.placeholder')}
+                    className="h-11 flex-1 rounded-full border border-border bg-surface px-5 font-mono text-sm text-fg placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+                <Button onClick={() => setVerified(Boolean(value.trim()))}>
+                    {t('results.verify.button')}
+                </Button>
+            </div>
+
+            {verified && (
+                <m.div
+                    initial={{opacity: 0, y: 8}}
+                    animate={{opacity: 1, y: 0}}
+                    className="mt-5 flex items-start gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4"
+                >
+                    <BadgeCheck className="mt-0.5 shrink-0 text-emerald-500" size={18}/>
+                    <div>
+                        <div className="text-sm font-semibold text-emerald-500">
+                            {t('results.verify.success')}
+                        </div>
+
+                        <div className="mt-0.5 text-xs text-muted">
+                            {t('results.verify.ranked')} {value}
+                        </div>
+                    </div>
+                </m.div>
+            )}
+        </div>
+    );
+}

--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -4,7 +4,6 @@ export * from './organization';
 export * from './organizationDraft';
 
 export * from './proposal';
+export * from './proposalState';
 export * from './proposalDraft';
-export * from './proposalState'
-
-export * from './proposalFilter'
+export * from './proposalFilter';

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -47,7 +47,8 @@
     "end-date": "Data de fi",
     "copied": "Copiat!",
     "copy": "Copia",
-    "position": "Posició {{n}}"
+    "position": "Posició {{n}}",
+    "live": "En directe"
   },
   "theme": {
     "toggle": "Canvia el tema",
@@ -266,10 +267,26 @@
     "confirmed": "Vot confirmat",
     "ranking": "La teva classificació",
     "results": {
-      "cta": "Mira els resultats"
+      "title": "Resultats",
+      "cta": "Mira els resultats",
+      "voters": "{{count}} votant",
+      "voters_other": "{{count}} votants",
+      "voters-label": "votants fins ara",
+      "in-progress": "Elecció en curs",
+      "in-progress-hint": "Els resultats estaran disponibles quan tanqui l'elecció. Els vots estan emmagatzemats a la cadena."
     },
     "opens-on": "La finestra de votació s'obre el {{date}}. Torna llavors per emetre el teu vot.",
     "closed-notice": "Aquesta elecció ha finalitzat."
+  },
+  "results": {
+    "verify": {
+      "title": "Verifica un vot",
+      "text": "Enganxa l'ID d'un rebut per comprovar de manera independent que una papereta ha estat comptada.",
+      "placeholder": "p. ex. DMCX-4F7A-92E1",
+      "button": "Verifica",
+      "success": "Aquesta papereta ha estat registrada i comptada.",
+      "ranked": "Classificada el"
+    }
   },
   "wallet": {
     "txid": "ID de transacció",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -47,7 +47,8 @@
     "end-date": "End Date",
     "copied": "Copied!",
     "copy": "Copy",
-    "position": "Position {{n}}"
+    "position": "Position {{n}}",
+    "live": "Live"
   },
   "theme": {
     "toggle": "Toggle theme",
@@ -266,10 +267,26 @@
     "confirmed": "Vote confirmed",
     "ranking": "Your ranking",
     "results": {
-      "cta": "See results"
+      "title": "Results",
+      "cta": "See results",
+      "voters": "{{count}} voter",
+      "voters_other": "{{count}} voters",
+      "voters-label": "voters so far",
+      "in-progress": "Election in progress",
+      "in-progress-hint": "Results will be available once the election closes. Ranked ballots are stored on-chain."
     },
     "opens-on": "The election window opens on {{date}}. Come back then to cast your vote.",
     "closed-notice": "This election has concluded."
+  },
+  "results": {
+    "verify": {
+      "title": "Verify a vote",
+      "text": "Paste a receipt ID to independently verify that a ballot was counted.",
+      "placeholder": "e.g. DMCX-4F7A-92E1",
+      "button": "Verify",
+      "success": "This ballot was recorded and counted.",
+      "ranked": "Ranked on"
+    }
   },
   "wallet": {
     "txid": "Transaction ID",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -47,7 +47,8 @@
     "end-date": "Fecha de finalización",
     "copied": "¡Copiado!",
     "copy": "Copia",
-    "position": "Posición {{n}}"
+    "position": "Posición {{n}}",
+    "live": "En vivo"
   },
   "theme": {
     "toggle": "Cambiar tema",
@@ -266,10 +267,26 @@
     "cta": "Emite tu voto preferencial",
     "ranking": "Tu clasificación",
     "results": {
-      "cta": "Ver resultados"
+      "title": "Resultados",
+      "cta": "Ver resultados",
+      "voters": "{{count}} votante",
+      "voters_other": "{{count}} votantes",
+      "voters-label": "votantes hasta ahora",
+      "in-progress": "Elección en curso",
+      "in-progress-hint": "Los resultados estarán disponibles cuando cierre la elección. Los votos están almacenados en la cadena."
     },
     "opens-on": "La ventana de votación abre el {{date}}. Vuelve entonces para emitir tu voto.",
     "closed-notice": "Esta elección ha finalizado."
+  },
+  "results": {
+    "verify": {
+      "title": "Verificar un voto",
+      "text": "Pega un ID de recibo para comprobar de forma independiente que una papeleta fue contada.",
+      "placeholder": "p. ej. DMCX-4F7A-92E1",
+      "button": "Verificar",
+      "success": "Esta papeleta fue registrada y contada.",
+      "ranked": "Clasificada el"
+    }
   },
   "wallet": {
     "txid": "ID de transacción",

--- a/client/src/pages/ResultsPage.tsx
+++ b/client/src/pages/ResultsPage.tsx
@@ -1,0 +1,129 @@
+import {m} from 'framer-motion';
+import {useTranslation} from 'react-i18next';
+import {useLoaderData, useNavigate} from 'react-router-dom';
+import {ArrowLeft, Radio, RefreshCw, Users} from 'lucide-react';
+
+import {useQuery} from '@tanstack/react-query';
+
+import type {ProposalId} from "@/domain";
+
+import {VerificationPanel} from '@/components/results/VerificationPanel';
+
+import {proposalQueries, votingQueries} from '@/algorand/queries';
+
+import {formatDatetime} from '@/utils/date';
+
+export function ResultsPage() {
+    const id = useLoaderData() as ProposalId;
+
+    const {t, i18n} = useTranslation();
+    const locale = i18n.resolvedLanguage ?? 'en';
+    const navigate = useNavigate();
+
+    const {data: proposal = null, isPending, error, refetch} = useQuery({
+        ...proposalQueries.detail(id)
+    });
+
+    const isLive = proposal?.state.kind === 'Open';
+    const isClosed = proposal?.state.kind === 'Closed';
+
+    const {data: voterCount = 0} = useQuery({
+        ...votingQueries.electionVoterCount(id),
+        refetchInterval: isLive ? 5000 : false,
+    });
+
+    const totalVoters = 0; /*TODO*/
+
+    if (isPending) {
+        return (
+            <div className="mx-auto max-w-4xl px-6 py-14">
+                <div className="mb-6 h-5 w-20 animate-pulse rounded-full bg-surface"/>
+                <div className="h-10 w-1/2 animate-pulse rounded-2xl bg-surface"/>
+                <div className="mt-10 h-40 animate-pulse rounded-3xl bg-surface"/>
+            </div>
+        );
+    }
+
+    if (error || !proposal) {
+        return (
+            <div className="mx-auto max-w-3xl px-6 py-20 text-center">
+                <p className="mb-4 text-muted">{error?.message ?? 'Proposal not found.'}</p>
+                <button
+                    onClick={() => void refetch()}
+                    className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm text-muted transition hover:text-fg"
+                >
+                    <RefreshCw size={14}/> {t('common.retry')}
+                </button>
+            </div>
+        );
+    }
+
+    const displayVoters = isClosed ? totalVoters : voterCount;
+
+    return (
+        <div className="mx-auto max-w-4xl px-6 py-14">
+            <button
+                onClick={() => navigate(-1)}
+                className="mb-6 inline-flex items-center gap-2 text-sm text-muted transition hover:text-fg"
+            >
+                <ArrowLeft size={16}/> {t('common.back')}
+            </button>
+
+            <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted">
+                {proposal.title}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+                <h1 className="font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+                    {t('vote.results.title')}
+                </h1>
+                {isLive && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-500">
+                        <Radio size={11} className="animate-pulse"/> {t('common.live')}
+                    </span>
+                )}
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-muted">
+                <span>{formatDatetime(proposal.startDate, locale)} → {formatDatetime(proposal.endDate, locale)}</span>
+                <span className="inline-flex items-center gap-1.5">
+                    <Users size={13}/>
+                    {t('vote.results.voters', {count: displayVoters})}
+                </span>
+            </div>
+
+            {/* ── Election in progress ── */}
+            {isLive && (
+                <m.div
+                    initial={{opacity: 0, y: 16}}
+                    animate={{opacity: 1, y: 0}}
+                    className="mt-10 rounded-3xl border border-border bg-surface p-10 text-center"
+                >
+                    <Radio size={32} className="mx-auto mb-4 animate-pulse text-primary"/>
+                    <h2 className="font-display text-2xl font-semibold text-fg">
+                        {t('vote.results.in-progress')}
+                    </h2>
+
+                    <p className="mt-2 text-sm text-muted">
+                        {t('vote.results.in-progress-hint')}
+                    </p>
+
+                    <p className="mt-5 font-display text-5xl font-bold tabular-nums text-fg">
+                        {voterCount}
+                    </p>
+
+                    <p className="mt-1 text-xs font-semibold uppercase tracking-wider text-muted">
+                        {t('vote.results.voters-label')}
+                    </p>
+                </m.div>
+            )}
+
+            {/* ── Final results (closed) ── */}
+            {isClosed && (
+                <>
+                    TODO
+                </>
+            )}
+
+            <VerificationPanel/>
+        </div>
+    );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -19,8 +19,10 @@ import {ProposalsPage} from "@/pages/ProposalsPage";
 import {NewProposalPage} from "@/pages/NewProposalPage";
 import {ProposalDetailPage} from "@/pages/ProposalDetailPage";
 
+import {VotePage} from "@/pages/VotePage";
+import {ResultsPage} from "@/pages/ResultsPage";
+
 import {parseRouteId} from "@/hooks/utils.ts";
-import {VotePage} from "@/pages/VotePage.tsx";
 
 export const router = createBrowserRouter([{
     element: <App/>,
@@ -97,6 +99,18 @@ export const router = createBrowserRouter([{
                 return id;
             },
             element: <VotePage/>,
+            errorElement: <RouteError/>,
+        },
+        {
+            path: '/proposals/:id/results',
+            loader: async ({params}) => {
+                const id = asProposalId(parseRouteId(params['id']));
+
+                await queryClient.ensureQueryData(proposalQueries.detail(id))
+
+                return id
+            },
+            element: <ResultsPage/>,
             errorElement: <RouteError/>,
         },
         {


### PR DESCRIPTION
## Descripció del canvi

S'implementa la pàgina de resultats d'una proposta que mostra el seguiment de la participació en temps real consultant el contracte d'Algorand. Inclou el component `VerificationPanel` per mostrar les dades de participació i verificació, amb la ruta corresponent afegida al router.

S'ha inclòs la pàgina de resultats perquè el seguiment en temps real i la visualització dels resultats finals es mostra a la mateixa pàgina. Quin dels dos estats es visualitza depèn de si la votació està oberta o no.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #337 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal