### PR TITLE
feat(client): implementació del mètode de Schulze per calcular resultats

### DIFF
--- a/client/src/domain/electionResults.test.ts
+++ b/client/src/domain/electionResults.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'bun:test';
+import { computeElectionResults } from './electionResults';
+import { asProposalId } from './proposal';
+
+const pid = asProposalId(1);
+
+describe('computeElectionResults', () => {
+  it('retorna un rànquing buit quan no hi ha paperetes', () => {
+    const results = computeElectionResults(pid, [], 3);
+    expect(results).toEqual({ proposalId: pid, ranking: [], totalVoters: 0 });
+  });
+
+  it('retorna un rànquing buit amb zero opcions', () => {
+    const results = computeElectionResults(pid, [[0, 1, 2]], 0);
+    expect(results.ranking).toEqual([]);
+    expect(results.totalVoters).toBe(0);
+  });
+
+  it('ordena primer el guanyador unànime', () => {
+    const paperetes = [
+      [0, 1, 2],
+      [0, 2, 1],
+      [0, 1, 2],
+    ];
+    const results = computeElectionResults(pid, paperetes, 3);
+    expect(results.totalVoters).toBe(3);
+    expect(results.ranking[0]).toEqual({ optionId: 0, firstChoiceVotes: 3, finalRank: 0 });
+  });
+
+  it('produeix un rànquing determinista amb totes les opcions ordenades', () => {
+    const paperetes = [
+      [0, 1, 2],
+      [0, 1, 2],
+      [1, 0, 2],
+    ];
+    const results = computeElectionResults(pid, paperetes, 3);
+    expect(results.ranking.length).toBe(3);
+    expect(results.ranking.map((r) => r.finalRank)).toEqual([0, 1, 2]);
+  });
+
+  it('compta correctament els vots de primera elecció', () => {
+    const paperetes = [
+      [0, 1, 2],
+      [1, 0, 2],
+      [1, 2, 0],
+      [2, 1, 0],
+    ];
+    const results = computeElectionResults(pid, paperetes, 3);
+    const perId = new Map(results.ranking.map((r) => [r.optionId, r.firstChoiceVotes]));
+    expect(perId.get(0)).toBe(1);
+    expect(perId.get(1)).toBe(2);
+    expect(perId.get(2)).toBe(1);
+  });
+
+  it('resol empats determinísticament per l\'índex d\'opció inferior', () => {
+    // Empat perfecte entre 0 i 1 (una papereta cadascun, preferències idèntiques).
+    const paperetes = [
+      [0, 1],
+      [1, 0],
+    ];
+    const results = computeElectionResults(pid, paperetes, 2);
+    // Empat → l'opció 0 primer per ordenació determinista.
+    expect(results.ranking[0].optionId).toBe(0);
+    expect(results.ranking[1].optionId).toBe(1);
+  });
+
+  it('retorna el proposalId al resultat', () => {
+    const idPersonalitzat = asProposalId(42);
+    const results = computeElectionResults(idPersonalitzat, [[0, 1]], 2);
+    expect(results.proposalId).toBe(idPersonalitzat);
+  });
+});

--- a/client/src/domain/electionResults.ts
+++ b/client/src/domain/electionResults.ts
@@ -1,0 +1,88 @@
+import type {ProposalId} from './proposal';
+
+export interface OptionResult {
+    /** Option index, matching `ProposalOption.id`. */
+    optionId: number;
+    firstChoiceVotes: number;
+    /** 0 = winner, ties broken deterministically by option index. */
+    finalRank: number;
+}
+
+export interface ElectionResults {
+    proposalId: ProposalId;
+    ranking: OptionResult[];
+    totalVoters: number;
+}
+
+/**
+ * Mètode de Schulze (variant de Schwartz Sequential Dropping / força de camí).
+ *
+ * 1. Construeix matriu per parelles d[i][j] = #voters que prefereixen i sobre j.
+ * 2. Calculeu la matriu de camí més fort p[i][j] utilitzant Floyd-Warshall.
+ * 3. Classificació: i supera j si p[i][j] > p[j][i]. Ordena per nombre d'opcions superades.
+ */
+export function computeElectionResults(proposalId: ProposalId, ballots: number[][], optionCount: number): ElectionResults {
+    if (ballots.length === 0 || optionCount === 0)
+        return {proposalId, ranking: [], totalVoters: 0};
+
+    const d: number[][] = Array.from({length: optionCount}, () =>
+        new Array(optionCount).fill(0)
+    );
+
+    for (const ballot of ballots) {
+        for (let rankI = 0; rankI < ballot.length; rankI++) {
+            for (let rankJ = rankI + 1; rankJ < ballot.length; rankJ++) {
+                const i = ballot[rankI];
+                const j = ballot[rankJ];
+
+                if (i < optionCount && j < optionCount)
+                    d[i][j]++;
+            }
+        }
+    }
+
+    const p: number[][] = Array.from({length: optionCount}, (_, i) =>
+        Array.from({length: optionCount}, (_, j) => {
+            return i === j
+                ? 0
+                : d[i][j] > d[j][i] ? d[i][j] : 0;
+        }),
+    );
+
+    for (let k = 0; k < optionCount; k++) {
+        for (let i = 0; i < optionCount; i++) {
+            for (let j = 0; j < optionCount; j++) {
+                if (i === j)
+                    continue;
+
+                p[i][j] = Math.max(p[i][j], Math.min(p[i][k], p[k][j]));
+            }
+        }
+    }
+
+    const wins = Array.from({length: optionCount}, (_, i) => {
+        let count = 0;
+
+        for (let j = 0; j < optionCount; j++)
+            if (i !== j && p[i][j] > p[j][i])
+                count++;
+
+        return {optionId: i, wins: count};
+    });
+
+    wins.sort((a, b) => b.wins - a.wins || a.optionId - b.optionId);
+
+    const firstChoiceCounts = new Array<number>(optionCount).fill(0);
+
+    for (const ballot of ballots)
+        if (ballot.length > 0 && ballot[0] < optionCount)
+            firstChoiceCounts[ballot[0]]++;
+
+    const ranking: OptionResult[] = wins.map(({optionId}, rank) => ({
+        optionId,
+        firstChoiceVotes: firstChoiceCounts[optionId],
+        finalRank: rank,
+    }));
+
+    return {proposalId, ranking, totalVoters: ballots.length};
+}

--- a/client/src/domain/index.ts
+++ b/client/src/domain/index.ts
@@ -7,3 +7,5 @@ export * from './proposal';
 export * from './proposalState';
 export * from './proposalDraft';
 export * from './proposalFilter';
+
+export * from './electionResults';


### PR DESCRIPTION
## Descripció del canvi

S'implementa el mètode de Schulze al domini del client per calcular els resultats d'una elecció a partir de les preferències dels votants. La lògica resideix íntegrament a `electionResults.ts` amb els tests corresponents, mantenint el càlcul desacoblat de la capa de presentació.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #132

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal