### PR TITLE
feat(client): pàgina de resultats finals d'una elecció

### DIFF
--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -1,6 +1,8 @@
 import {queryOptions} from '@tanstack/react-query';
 
-import type {Address, Organization, OrganizationId, Proposal, ProposalId} from '@/domain';
+import type {Address, Organization, OrganizationId, Proposal, ProposalId, ElectionResults} from '@/domain';
+
+import {asProposalId, computeElectionResults} from "@/domain"
 
 import {
     getOrganization,
@@ -19,7 +21,8 @@ import {
 import {
     hasApprovalVoted,
     hasElectionVoted,
-    getElectionVoterCount
+    getElectionVoterCount,
+    getElectionBallots
 } from "./voting";
 
 import {mapToOrganization, mapToProposal} from './mappers';
@@ -91,6 +94,11 @@ async function fetchElectionVoterCount(proposalId: ProposalId): Promise<number> 
     return getElectionVoterCount(proposalId);
 }
 
+async function fetchElectionResults(proposalId: ProposalId, numOptions: number): Promise<ElectionResults> {
+    const ballots = await getElectionBallots(proposalId);
+    return computeElectionResults(asProposalId(proposalId), ballots, numOptions);
+}
+
 // ── Query options (co-locate key + fn for use in useQuery / prefetch) ─
 
 export const organizationQueries = {
@@ -140,4 +148,8 @@ export const votingQueries = {
         queryKey: queryKeys.voting.electionVoterCount(proposalId),
         queryFn: () => fetchElectionVoterCount(proposalId),
     }),
+    electionResults: (proposalId: ProposalId, numOptions: number) => queryOptions({
+        queryKey: queryKeys.voting.electionResults(proposalId),
+        queryFn: () => fetchElectionResults(proposalId, numOptions),
+    })
 }

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -18,6 +18,7 @@ export const queryKeys = {
         approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const,
         electionVoted: (address: Address, proposalId: ProposalId) => ['voting', 'election', address, proposalId] as const,
         electionVoterCount: (proposalId: ProposalId) => ['election', 'voterCount', proposalId] as const,
+        electionResults: (proposalId: ProposalId) => ['election', 'results', proposalId] as const
     },
     electionPrefix: ['election'] as const
 }

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -93,3 +93,40 @@ export async function hasApprovalVoted(sender: Address, proposalId: ProposalId):
 export async function hasElectionVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
     return boxExists(electionBallotKey(sender, proposalId));
 }
+
+export async function getElectionBallots(proposalId: ProposalId): Promise<number[][]> {
+    try {
+        const {boxes} = await algodClient.getApplicationBoxes(APP_ID).do();
+        const prefix = enc.encode('eb_');
+        const pidBytes = algosdk.bigIntToBytes(proposalId, 8);
+
+        const ballotBoxNames: Uint8Array[] = [];
+
+        for (const b of boxes) {
+            const name = b.name;
+
+            if (
+                name.length === 43 &&
+                bytesEqual(name.slice(0, 3), prefix) &&
+                bytesEqual(name.slice(35), pidBytes)
+            ) {
+                ballotBoxNames.push(name);
+            }
+        }
+
+        return await Promise.all(
+            ballotBoxNames.map(async (name) => {
+                const box = await algodClient.getApplicationBoxByName(APP_ID, name).do();
+                return decodePreferenceOrder(box.value);
+            }),
+        );
+    } catch {
+        return [];
+    }
+}
+
+function decodePreferenceOrder(data: Uint8Array): number[] {
+    const type = algosdk.ABIType.from('uint8[]');
+    const decoded = type.decode(data) as bigint[];
+    return decoded.map(Number);
+}

--- a/client/src/domain/electionResults.test.ts
+++ b/client/src/domain/electionResults.test.ts
@@ -1,72 +1,73 @@
-import { describe, it, expect } from 'bun:test';
-import { computeElectionResults } from './electionResults';
-import { asProposalId } from './proposal';
+import {describe, it, expect} from 'bun:test';
+
+import {computeElectionResults} from './electionResults';
+import {asProposalId} from './proposal';
 
 const pid = asProposalId(1);
 
 describe('computeElectionResults', () => {
-  it('retorna un rànquing buit quan no hi ha paperetes', () => {
-    const results = computeElectionResults(pid, [], 3);
-    expect(results).toEqual({ proposalId: pid, ranking: [], totalVoters: 0 });
-  });
+    it('retorna un rànquing buit quan no hi ha paperetes', () => {
+        const results = computeElectionResults(pid, [], 3);
+        expect(results).toEqual({proposalId: pid, ranking: [], totalVoters: 0});
+    });
 
-  it('retorna un rànquing buit amb zero opcions', () => {
-    const results = computeElectionResults(pid, [[0, 1, 2]], 0);
-    expect(results.ranking).toEqual([]);
-    expect(results.totalVoters).toBe(0);
-  });
+    it('retorna un rànquing buit amb zero opcions', () => {
+        const results = computeElectionResults(pid, [[0, 1, 2]], 0);
+        expect(results.ranking).toEqual([]);
+        expect(results.totalVoters).toBe(0);
+    });
 
-  it('ordena primer el guanyador unànime', () => {
-    const paperetes = [
-      [0, 1, 2],
-      [0, 2, 1],
-      [0, 1, 2],
-    ];
-    const results = computeElectionResults(pid, paperetes, 3);
-    expect(results.totalVoters).toBe(3);
-    expect(results.ranking[0]).toEqual({ optionId: 0, firstChoiceVotes: 3, finalRank: 0 });
-  });
+    it('ordena primer el guanyador unànime', () => {
+        const paperetes = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [0, 1, 2],
+        ];
+        const results = computeElectionResults(pid, paperetes, 3);
+        expect(results.totalVoters).toBe(3);
+        expect(results.ranking[0]).toEqual({optionId: 0, firstChoiceVotes: 3, finalRank: 0});
+    });
 
-  it('produeix un rànquing determinista amb totes les opcions ordenades', () => {
-    const paperetes = [
-      [0, 1, 2],
-      [0, 1, 2],
-      [1, 0, 2],
-    ];
-    const results = computeElectionResults(pid, paperetes, 3);
-    expect(results.ranking.length).toBe(3);
-    expect(results.ranking.map((r) => r.finalRank)).toEqual([0, 1, 2]);
-  });
+    it('produeix un rànquing determinista amb totes les opcions ordenades', () => {
+        const paperetes = [
+            [0, 1, 2],
+            [0, 1, 2],
+            [1, 0, 2],
+        ];
+        const results = computeElectionResults(pid, paperetes, 3);
+        expect(results.ranking.length).toBe(3);
+        expect(results.ranking.map((r) => r.finalRank)).toEqual([0, 1, 2]);
+    });
 
-  it('compta correctament els vots de primera elecció', () => {
-    const paperetes = [
-      [0, 1, 2],
-      [1, 0, 2],
-      [1, 2, 0],
-      [2, 1, 0],
-    ];
-    const results = computeElectionResults(pid, paperetes, 3);
-    const perId = new Map(results.ranking.map((r) => [r.optionId, r.firstChoiceVotes]));
-    expect(perId.get(0)).toBe(1);
-    expect(perId.get(1)).toBe(2);
-    expect(perId.get(2)).toBe(1);
-  });
+    it('compta correctament els vots de primera elecció', () => {
+        const paperetes = [
+            [0, 1, 2],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 1, 0],
+        ];
+        const results = computeElectionResults(pid, paperetes, 3);
+        const perId = new Map(results.ranking.map((r) => [r.optionId, r.firstChoiceVotes]));
+        expect(perId.get(0)).toBe(1);
+        expect(perId.get(1)).toBe(2);
+        expect(perId.get(2)).toBe(1);
+    });
 
-  it('resol empats determinísticament per l\'índex d\'opció inferior', () => {
-    // Empat perfecte entre 0 i 1 (una papereta cadascun, preferències idèntiques).
-    const paperetes = [
-      [0, 1],
-      [1, 0],
-    ];
-    const results = computeElectionResults(pid, paperetes, 2);
-    // Empat → l'opció 0 primer per ordenació determinista.
-    expect(results.ranking[0].optionId).toBe(0);
-    expect(results.ranking[1].optionId).toBe(1);
-  });
+    it('resol empats determinísticament per l\'índex d\'opció inferior', () => {
+        // Empat perfecte entre 0 i 1 (una papereta cadascun, preferències idèntiques).
+        const paperetes = [
+            [0, 1],
+            [1, 0],
+        ];
+        const results = computeElectionResults(pid, paperetes, 2);
+        // Empat → l'opció 0 primer per ordenació determinista.
+        expect(results.ranking[0].optionId).toBe(0);
+        expect(results.ranking[1].optionId).toBe(1);
+    });
 
-  it('retorna el proposalId al resultat', () => {
-    const idPersonalitzat = asProposalId(42);
-    const results = computeElectionResults(idPersonalitzat, [[0, 1]], 2);
-    expect(results.proposalId).toBe(idPersonalitzat);
-  });
+    it('retorna el proposalId al resultat', () => {
+        const idPersonalitzat = asProposalId(42);
+        const results = computeElectionResults(idPersonalitzat, [[0, 1]], 2);
+        expect(results.proposalId).toBe(idPersonalitzat);
+    });
 });

--- a/client/src/i18n/locales/ca.json
+++ b/client/src/i18n/locales/ca.json
@@ -286,7 +286,13 @@
       "button": "Verifica",
       "success": "Aquesta papereta ha estat registrada i comptada.",
       "ranked": "Classificada el"
-    }
+    },
+    "no-votes": "No es va emetre cap vot en aquesta elecció.",
+    "winner": "Guanyadora",
+    "first-choice-votes": "Vots de primera opció",
+    "first-choise-short": "1a opció",
+    "ranking": "Classificació completa",
+    "schulze-note": "El guanyador es determina pel mètode Schulze. La barra mostra els vots de primera opció."
   },
   "wallet": {
     "txid": "ID de transacció",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -286,7 +286,13 @@
       "button": "Verify",
       "success": "This ballot was recorded and counted.",
       "ranked": "Ranked on"
-    }
+    },
+    "no-votes": "No votes were cast in this election.",
+    "winner": "Winner",
+    "first-choice-votes": "First-choice votes",
+    "first-choise-short": "1st choice",
+    "ranking": "Full ranking",
+    "schulze-note": "Winner determined by the Schulze method. Bar shows first-choice votes."
   },
   "wallet": {
     "txid": "Transaction ID",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -286,7 +286,13 @@
       "button": "Verificar",
       "success": "Esta papeleta fue registrada y contada.",
       "ranked": "Clasificada el"
-    }
+    },
+    "no-votes": "No se emitió ningún voto en esta elección.",
+    "winner": "Ganadora",
+    "first-choice-votes": "Votos de primera opción",
+    "first-choise-short": "1ª opción",
+    "ranking": "Clasificación completa",
+    "schulze-note": "El ganador se determina por el método Schulze. La barra muestra los votos de primera opción."
   },
   "wallet": {
     "txid": "ID de transacción",

--- a/client/src/pages/ResultsPage.tsx
+++ b/client/src/pages/ResultsPage.tsx
@@ -1,15 +1,14 @@
 import {m} from 'framer-motion';
 import {useTranslation} from 'react-i18next';
 import {useLoaderData, useNavigate} from 'react-router-dom';
-import {ArrowLeft, Radio, RefreshCw, Users} from 'lucide-react';
+import {ArrowLeft, Radio, RefreshCw, Trophy, Users} from 'lucide-react';
 
 import {useQuery} from '@tanstack/react-query';
+import {proposalQueries, votingQueries} from '@/algorand/queries';
 
 import type {ProposalId} from "@/domain";
 
 import {VerificationPanel} from '@/components/results/VerificationPanel';
-
-import {proposalQueries, votingQueries} from '@/algorand/queries';
 
 import {formatDatetime} from '@/utils/date';
 
@@ -32,7 +31,13 @@ export function ResultsPage() {
         refetchInterval: isLive ? 5000 : false,
     });
 
-    const totalVoters = 0; /*TODO*/
+    const {data: electionResults = null, isPending: resultsLoading, error: resultsError} = useQuery({
+        ...votingQueries.electionResults(id, proposal?.options.length ?? 0),
+        enabled: isClosed
+    });
+
+    const results = electionResults?.ranking ?? [];
+    const totalVoters = electionResults?.totalVoters ?? 0;
 
     if (isPending) {
         return (
@@ -72,16 +77,19 @@ export function ResultsPage() {
             <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted">
                 {proposal.title}
             </div>
+
             <div className="flex flex-wrap items-center gap-3">
                 <h1 className="font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
                     {t('vote.results.title')}
                 </h1>
                 {isLive && (
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-500">
+                    <span
+                        className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-500">
                         <Radio size={11} className="animate-pulse"/> {t('common.live')}
                     </span>
                 )}
             </div>
+
             <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-muted">
                 <span>{formatDatetime(proposal.startDate, locale)} → {formatDatetime(proposal.endDate, locale)}</span>
                 <span className="inline-flex items-center gap-1.5">
@@ -98,6 +106,7 @@ export function ResultsPage() {
                     className="mt-10 rounded-3xl border border-border bg-surface p-10 text-center"
                 >
                     <Radio size={32} className="mx-auto mb-4 animate-pulse text-primary"/>
+
                     <h2 className="font-display text-2xl font-semibold text-fg">
                         {t('vote.results.in-progress')}
                     </h2>
@@ -119,7 +128,130 @@ export function ResultsPage() {
             {/* ── Final results (closed) ── */}
             {isClosed && (
                 <>
-                    TODO
+                    {resultsLoading && (
+                        <div className="mt-10 space-y-3">
+                            {['rs-a', 'rs-b', 'rs-c'].map((k) => (
+                                <div key={k} className="h-16 animate-pulse rounded-2xl bg-surface"/>
+                            ))}
+                        </div>
+                    )}
+
+                    {resultsError && <p className="mt-10 text-center text-sm text-muted">{resultsError.message}</p>}
+
+                    {!resultsLoading && !resultsError && results.length === 0 && (
+                        <div
+                            className="mt-10 rounded-2xl border border-dashed border-border p-12 text-center text-muted">
+                            {t('results.no-votes')}
+                        </div>
+                    )}
+
+                    {!resultsLoading && results.length > 0 && (() => {
+                        const winner = results[0];
+                        const winnerOpt = proposal.options.find((o) => o.id === winner.optionId);
+                        const maxVotes = results[0].firstChoiceVotes || 1;
+
+                        return (
+                            <>
+                                {/* Winner card */}
+                                <m.div
+                                    initial={{opacity: 0, y: 20}}
+                                    animate={{opacity: 1, y: 0}}
+                                    transition={{duration: 0.5}}
+                                    className="relative mt-10 overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-primary/20 via-surface to-accent/20 p-8"
+                                >
+                                    <div className="absolute -right-20 -top-20 size-64 rounded-full bg-primary/20 blur-3xl"/>
+                                    <div className="relative flex flex-wrap items-center justify-between gap-6">
+                                        <div>
+                                            <div
+                                                className="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary"
+                                            >
+                                                <Trophy size={14}/> {t('results.winner')}
+                                            </div>
+                                            <h2 className="font-display text-3xl font-semibold text-fg sm:text-4xl">
+                                                {winnerOpt?.title}
+                                            </h2>
+                                        </div>
+
+                                        <div className="text-right">
+                                            <div className="text-xs font-semibold uppercase tracking-wider text-muted">
+                                                {t('results.first-choice-votes')}
+                                            </div>
+
+                                            <div className="font-display text-5xl font-bold tabular-nums text-fg">
+                                                {winner.firstChoiceVotes}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </m.div>
+
+                                {/* Full ranking */}
+                                <h3 className="mb-4 mt-12 text-xs font-semibold uppercase tracking-wider text-muted">
+                                    {t('results.ranking')}
+                                </h3>
+
+                                <ul className="space-y-3">
+                                    {results.map((r, i) => {
+                                        const opt = proposal.options.find(o =>
+                                            o.id === r.optionId
+                                        );
+
+                                        const widthPct = (r.firstChoiceVotes / maxVotes) * 100;
+
+                                        return (
+                                            <m.li
+                                                key={r.optionId}
+                                                initial={{opacity: 0, x: -10}}
+                                                animate={{opacity: 1, x: 0}}
+                                                transition={{duration: 0.4, delay: i * 0.05}}
+                                                className="relative overflow-hidden rounded-2xl border border-border bg-surface p-4"
+                                            >
+                                                <div className="relative flex items-center gap-4">
+                                                    <div
+                                                        className={`flex size-10 shrink-0 items-center justify-center rounded-full font-display text-sm font-bold ${
+                                                            i === 0
+                                                                ? 'bg-gradient-to-br from-primary to-accent text-primary-fg'
+                                                                : 'bg-primary/10 text-primary'
+                                                        }`}
+                                                    >
+                                                        {i + 1}
+                                                    </div>
+                                                    <div className="min-w-0 flex-1">
+                                                        <div className="flex items-center justify-between gap-2">
+                                                            <span className="truncate text-sm font-semibold text-fg">
+                                                                {opt?.title}
+                                                            </span>
+
+                                                            <span className="tabular-nums text-sm text-muted">
+                                                                {r.firstChoiceVotes} {t('results.first-choice-short')}
+                                                            </span>
+                                                        </div>
+                                                        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-border">
+                                                            <m.div
+                                                                initial={{width: 0}}
+                                                                animate={{width: `${widthPct}%`}}
+                                                                transition={{
+                                                                    duration: 0.8,
+                                                                    delay: 0.2 + i * 0.08,
+                                                                    ease: 'easeOut'
+                                                                }}
+                                                                className={`h-full rounded-full ${
+                                                                    i === 0 ? 'bg-gradient-to-r from-primary to-accent' : 'bg-primary/60'
+                                                                }`}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </m.li>
+                                        );
+                                    })}
+                                </ul>
+
+                                <p className="mt-4 text-center text-xs text-muted">
+                                    {t('results.schulze-note')}
+                                </p>
+                            </>
+                        );
+                    })()}
                 </>
             )}
 


### PR DESCRIPTION
## Descripció del canvi

S'implementa la pàgina de resultats finals que consulta les paperetes emeses al contracte d'Algorand, aplica el mètode de Schulze i mostra el rànquing guanyador de l'elecció. S'amplien les queries i el mòdul `voting.ts` per obtenir les dades necessàries i s'actualitza `ResultsPage` per integrar el càlcul i la visualització dels resultats.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #136 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal