### PR TITLE
feat(client): matriu de duels un contra un i detecció d'empats

### DIFF
--- a/client/src/components/results/ClosedResults.tsx
+++ b/client/src/components/results/ClosedResults.tsx
@@ -1,0 +1,196 @@
+import {m} from "framer-motion";
+import {Link} from "react-router-dom";
+import {useTranslation} from "react-i18next";
+import {Plus, Scale, Trophy} from "lucide-react";
+
+import type {Proposal, ElectionResults} from "@/domain";
+
+import {PairwiseGrid} from "@/components/results/PairwiseGrid";
+
+interface ClosedResultsProps {
+    proposal: Proposal;
+    electionResults: ElectionResults | null;
+    resultsLoading: boolean;
+    resultsError: Error | null;
+}
+
+export function ClosedResults({proposal, electionResults, resultsLoading, resultsError}: ClosedResultsProps) {
+    const {t} = useTranslation();
+
+    const results = electionResults?.ranking ?? [];
+    const pairwiseMatrix = electionResults?.pairwiseMatrix ?? [];
+
+    if (resultsLoading) {
+        return (
+            <div className="mt-10 space-y-3">
+                {['rs-a', 'rs-b', 'rs-c'].map((k) => (
+                    <div key={k} className="h-16 animate-pulse rounded-2xl bg-surface"/>
+                ))}
+            </div>
+        );
+    }
+
+    if (resultsError)
+        return (
+            <p className="mt-10 text-center text-sm text-muted">
+                {resultsError.message}
+            </p>
+        );
+
+    if (results.length === 0) {
+        return (
+            <div className="mt-10 rounded-2xl border border-dashed border-border p-12 text-center text-muted">
+                {t('results.no-votes')}
+            </div>
+        );
+    }
+
+    const winner = results[0];
+    const winnerOpt = proposal.options.find(o => o.id === winner.optionId);
+    const optionCount = proposal.options.length;
+    const maxPairwiseWins = optionCount - 1;
+    const isTied = optionCount > 1 && winner.pairwiseWins === (results[1]?.pairwiseWins ?? -1);
+    const maxFirstChoice = Math.max(...results.map(r => r.firstChoiceVotes), 1);
+    void maxFirstChoice;
+
+    const totalPrefs = new Map<number, number>();
+
+    for (const opt of proposal.options) {
+        const row = pairwiseMatrix[opt.id] ?? [];
+        totalPrefs.set(opt.id, row.reduce((sum, v, j) => (j !== opt.id ? sum + v : sum), 0));
+    }
+
+    const maxTotalPrefs = Math.max(...totalPrefs.values(), 1);
+
+    return (
+        <>
+            {isTied ? (
+                <m.div
+                    initial={{opacity: 0, y: 20}} animate={{opacity: 1, y: 0}} transition={{duration: 0.5}}
+                    className="flex flex-col items-center mt-10 rounded-3xl border border-amber-500/25 bg-amber-500/5 p-8 text-center"
+                >
+                    <Scale size={32} className="mb-4 text-amber-400"/>
+                    <h2 className="font-display text-2xl font-semibold text-fg">
+                        {t('results.tie-title')}
+                    </h2>
+
+                    <p className="mt-2 max-w-xl text-sm text-muted">
+                        {t('results.tie-description')}
+                    </p>
+
+                    <p className="mt-10 max-w-sm text-sm text-muted">
+                        {t('results.tie-suggestion')}
+                    </p>
+
+                    <Link
+                        to="/proposals/new"
+                        className="mt-5 inline-flex items-center gap-2 rounded-full bg-amber-500/15 border border-amber-500/25 px-4 py-2 text-sm font-semibold text-amber-300 transition hover:bg-amber-500/25"
+                    >
+                        <Plus size={14}/> {t('results.tie-new-proposal')}
+                    </Link>
+                </m.div>
+            ) : (
+                <m.div
+                    initial={{opacity: 0, y: 20}} animate={{opacity: 1, y: 0}} transition={{duration: 0.5}}
+                    className="relative mt-10 overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-primary/20 via-surface to-accent/20 p-8"
+                >
+                    <div className="absolute -right-20 -top-20 size-64 rounded-full bg-primary/20 blur-3xl"/>
+                    <div className="relative flex flex-wrap items-center justify-between gap-6">
+                        <div>
+                            <div
+                                className="mb-2 inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-amber-400"
+                            >
+                                <Trophy size={14}/> {t('results.winner')}
+                            </div>
+
+                            <h2 className="font-display text-3xl font-semibold text-fg sm:text-4xl">
+                                {winnerOpt?.title}
+                            </h2>
+                        </div>
+
+                        <div className="text-right">
+                            <div className="text-xs font-semibold uppercase tracking-wider text-muted">
+                                {t('results.pairwise-wins', {wins: winner.pairwiseWins, total: maxPairwiseWins})}
+                            </div>
+
+                            <div className="mt-1 text-xs text-muted/60">
+                                {t('results.first-choice-secondary', {count: winner.firstChoiceVotes})}
+                            </div>
+                        </div>
+                    </div>
+                </m.div>
+            )}
+
+            <h3 className="mb-4 mt-12 text-xs font-semibold uppercase tracking-wider text-muted">
+                {isTied ? t('results.all-options') : t('results.ranking')}
+            </h3>
+
+            <ul className="space-y-4">
+                {results.map((r, i) => {
+                    const opt = proposal.options.find((o) => o.id === r.optionId);
+                    const prefs = totalPrefs.get(r.optionId) ?? 0;
+                    const barPct = (prefs / maxTotalPrefs) * 100;
+
+                    return (
+                        <m.li
+                            key={r.optionId}
+                            initial={{opacity: 0, x: -10}} animate={{opacity: 1, x: 0}}
+                            transition={{duration: 0.4, delay: i * 0.05}}
+                            className="rounded-2xl border border-border bg-surface p-5 sm:p-6"
+                        >
+                            <div className="flex items-start gap-4">
+                                <div
+                                    className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 font-display text-sm font-bold text-primary"
+                                >
+                                    {i + 1}
+                                </div>
+
+                                <div className="min-w-0 flex-1">
+                                    <span className="block truncate font-semibold text-fg">
+                                        {opt?.title}
+                                    </span>
+
+                                    <div className="mt-3 flex flex-wrap gap-2">
+                                        <span
+                                            className="inline-flex items-center rounded-full border border-sky-500/20 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-400"
+                                        >
+                                            {t('results.stat-duels', {wins: r.pairwiseWins, total: maxPairwiseWins})}
+                                        </span>
+
+                                        <span
+                                            className="inline-flex items-center rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-400"
+                                        >
+                                            {t('results.stat-first-choice', {count: r.firstChoiceVotes})}
+                                        </span>
+
+                                        <span
+                                            className="inline-flex items-center rounded-full border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-xs font-semibold text-violet-400"
+                                        >
+                                            {t('results.stat-total-prefs', {count: prefs})}
+                                        </span>
+                                    </div>
+
+                                    <div className="mt-3 h-2 overflow-hidden rounded-full bg-border">
+                                        <m.div
+                                            initial={{width: 0}} animate={{width: `${barPct}%`}}
+                                            transition={{duration: 0.8, delay: 0.2 + i * 0.08, ease: 'easeOut'}}
+                                            className="h-full rounded-full bg-gradient-to-r from-violet-500/80 to-primary/60"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </m.li>
+                    );
+                })}
+            </ul>
+
+            <p className="mt-4 text-center text-xs text-muted">
+                {t('results.schulze-note')}
+            </p>
+
+            {pairwiseMatrix.length > 0 && (
+                <PairwiseGrid options={proposal.options} pairwiseMatrix={pairwiseMatrix}/>
+            )}
+        </>
+    );
+}

--- a/client/src/components/results/PairwiseGrid.tsx
+++ b/client/src/components/results/PairwiseGrid.tsx
@@ -1,0 +1,97 @@
+import {m} from "framer-motion";
+
+import {useTranslation} from "react-i18next";
+
+import type {Proposal} from "@/domain";
+
+interface PairwiseGridProps {
+    options: Proposal['options'];
+    pairwiseMatrix: number[][];
+}
+
+export function PairwiseGrid({options, pairwiseMatrix}: PairwiseGridProps) {
+    const {t} = useTranslation();
+
+    return (
+        <m.div
+            initial={{opacity: 0, y: 12}}
+            animate={{opacity: 1, y: 0}}
+            transition={{duration: 0.5, delay: 0.3}}
+            className="mt-10"
+        >
+            <div className="mb-5">
+                <h3 className="text-sm font-semibold text-fg">
+                    {t('results.pairwise-section')}
+                </h3>
+
+                <p className="mt-1 text-xs leading-relaxed text-muted/80">
+                    {t('results.pairwise-explanation')}
+                </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {options.flatMap((optA, ai) =>
+                    options.slice(ai + 1).map((optB) => {
+                        const votesA = pairwiseMatrix[optA.id]?.[optB.id] ?? 0;
+                        const votesB = pairwiseMatrix[optB.id]?.[optA.id] ?? 0;
+                        const isWinA = votesA > votesB;
+                        const isWinB = votesB > votesA;
+                        const isTied = votesA === votesB;
+
+                        return (
+                            <div key={`${optA.id}-${optB.id}`}
+                                 className="overflow-hidden rounded-2xl border border-border bg-surface">
+                                <div className="flex items-center gap-3 px-4 pb-3 pt-4">
+                                    <span
+                                        className={`flex-1 truncate text-sm font-semibold ${isWinA ? 'text-emerald-400' : isTied ? 'text-amber-400' : 'text-rose-400/50'}`}
+                                    >
+                                        {optA.title}
+                                    </span>
+                                    <span
+                                        className="shrink-0 rounded-full border border-border px-2 py-0.5 text-xs font-bold text-muted/40">
+                                        vs
+                                    </span>
+                                    <span
+                                        className={`flex-1 truncate text-right text-sm font-semibold ${isWinB ? 'text-emerald-400' : isTied ? 'text-amber-400' : 'text-rose-400/50'}`}
+                                    >
+                                        {optB.title}
+                                    </span>
+                                </div>
+
+                                <div className="mx-4 flex h-14 gap-1 overflow-hidden rounded-xl">
+                                    <div
+                                        style={{flex: votesA + 1}}
+                                        className={`flex items-center justify-center font-display text-2xl font-bold tabular-nums ${isWinA ? 'bg-emerald-500/35 text-emerald-100' : isTied ? 'bg-amber-500/25 text-amber-100' : 'bg-rose-500/20 text-rose-300/60'}`}
+                                    >
+                                        {votesA}
+                                    </div>
+                                    <div style={{flex: votesB + 1}}
+                                         className={`flex items-center justify-center font-display text-2xl font-bold tabular-nums ${isWinB ? 'bg-emerald-500/35 text-emerald-100' : isTied ? 'bg-amber-500/25 text-amber-100' : 'bg-rose-500/20 text-rose-300/60'}`}
+                                    >
+                                        {votesB}
+                                    </div>
+                                </div>
+
+                                <div className="px-4 pb-4 pt-3 text-center">
+                                    {isTied ? (
+                                        <span
+                                            className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/15 px-3 py-1 text-xs font-medium text-amber-300"
+                                        >
+                                            {t('results.pairwise-legend-tie')}
+                                        </span>
+                                    ) : (
+                                        <span
+                                            className="inline-flex items-center rounded-full border border-emerald-500/25 bg-emerald-500/15 px-3 py-1 text-xs font-medium text-emerald-300"
+                                        >
+                                            {t('results.pairwise-matchup-win', {name: isWinA ? optA.title : optB.title})}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+        </m.div>
+    );
+}

--- a/client/src/domain/electionResults.test.ts
+++ b/client/src/domain/electionResults.test.ts
@@ -8,11 +8,13 @@ const pid = asProposalId(1);
 describe('computeElectionResults', () => {
     it('retorna un rànquing buit quan no hi ha paperetes', () => {
         const results = computeElectionResults(pid, [], 3);
-        expect(results).toEqual({proposalId: pid, ranking: [], totalVoters: 0});
+
+        expect(results).toEqual({proposalId: pid, ranking: [], totalVoters: 0, pairwiseMatrix: []});
     });
 
     it('retorna un rànquing buit amb zero opcions', () => {
         const results = computeElectionResults(pid, [[0, 1, 2]], 0);
+
         expect(results.ranking).toEqual([]);
         expect(results.totalVoters).toBe(0);
     });
@@ -23,9 +25,11 @@ describe('computeElectionResults', () => {
             [0, 2, 1],
             [0, 1, 2],
         ];
+
         const results = computeElectionResults(pid, paperetes, 3);
+
         expect(results.totalVoters).toBe(3);
-        expect(results.ranking[0]).toEqual({optionId: 0, firstChoiceVotes: 3, finalRank: 0});
+        expect(results.ranking[0]).toEqual({optionId: 0, firstChoiceVotes: 3, finalRank: 0, pairwiseWins: 2});
     });
 
     it('produeix un rànquing determinista amb totes les opcions ordenades', () => {
@@ -34,7 +38,9 @@ describe('computeElectionResults', () => {
             [0, 1, 2],
             [1, 0, 2],
         ];
+
         const results = computeElectionResults(pid, paperetes, 3);
+
         expect(results.ranking.length).toBe(3);
         expect(results.ranking.map((r) => r.finalRank)).toEqual([0, 1, 2]);
     });
@@ -46,8 +52,10 @@ describe('computeElectionResults', () => {
             [1, 2, 0],
             [2, 1, 0],
         ];
+
         const results = computeElectionResults(pid, paperetes, 3);
         const perId = new Map(results.ranking.map((r) => [r.optionId, r.firstChoiceVotes]));
+
         expect(perId.get(0)).toBe(1);
         expect(perId.get(1)).toBe(2);
         expect(perId.get(2)).toBe(1);
@@ -59,7 +67,9 @@ describe('computeElectionResults', () => {
             [0, 1],
             [1, 0],
         ];
+
         const results = computeElectionResults(pid, paperetes, 2);
+
         // Empat → l'opció 0 primer per ordenació determinista.
         expect(results.ranking[0].optionId).toBe(0);
         expect(results.ranking[1].optionId).toBe(1);
@@ -68,6 +78,79 @@ describe('computeElectionResults', () => {
     it('retorna el proposalId al resultat', () => {
         const idPersonalitzat = asProposalId(42);
         const results = computeElectionResults(idPersonalitzat, [[0, 1]], 2);
+
         expect(results.proposalId).toBe(idPersonalitzat);
+    });
+
+    it('el guanyador Condorcet guanya sempre, fins i tot sense vots de primera opció', () => {
+        // Cas típic de confusió: l'opció 0 NO té cap vot de primera opció però
+        // tots els votants la posen com a 2a opció → guanya totes les comparatives.
+        //   Vot A: [1, 0, 2]  →  d[1][0]++, d[1][2]++, d[0][2]++
+        //   Vot B: [2, 0, 1]  →  d[2][0]++, d[2][1]++, d[0][1]++
+        // Resultat: d[0][1]=1:1=d[1][0] i d[0][2]=1:1=d[2][0] → empat perfecte de 1:1 (tot tied)
+        // Però si hi ha 3 vots A i 1 vot B, l'opció 0 guanya cap a cap contra 1 i 2.
+        const paperetes = [
+            [1, 0, 2], // d[1][0]++, d[0][2]++
+            [1, 0, 2], // d[1][0]++, d[0][2]++
+            [1, 0, 2], // d[1][0]++, d[0][2]++
+            [2, 0, 1], // d[2][0]++, d[0][1]++
+            [2, 0, 1], // d[2][0]++, d[0][1]++
+        ];
+        // d[0][1]=2 d[1][0]=3  → 1 guanya cap a cap contra 0
+        // d[0][2]=3 d[2][0]=2  → 0 guanya cap a cap contra 2
+        // d[1][2]=3 d[2][1]=2  → 1 guanya cap a cap contra 2
+        // Schulze: 1 guanya (2 victòries: sobre 0 i 2), 0 és segon (1 victòria: sobre 2)
+
+        const results = computeElectionResults(pid, paperetes, 3);
+
+        expect(results.ranking[0].optionId).toBe(1);  // Opció 1 guanya
+        expect(results.ranking[0].firstChoiceVotes).toBe(3);
+        expect(results.ranking[0].pairwiseWins).toBe(2);
+        expect(results.ranking[2].optionId).toBe(2);  // Opció 2 és darrera
+    });
+
+    it('empat perfecte: tots 0 victòries, es resol per índex', () => {
+        // Cas de la imatge reportada: 2 vots [1,0,2] i 2 vots [2,0,1]
+        // Totes les comparatives queden 2:2 → ningú té victòries Schulze
+        // L'opció 0 guanya pel desempat d'índex (índex menor), malgrat tenir 0 vots de primera opció.
+        // El component ResultsPage detecta correctament aquest cas com a "empat" (isTied = true).
+        const paperetes = [
+            [1, 0, 2],
+            [1, 0, 2],
+            [2, 0, 1],
+            [2, 0, 1],
+        ];
+
+        const results = computeElectionResults(pid, paperetes, 3);
+
+        // Totes les comparatives empaten 2:2
+        expect(results.pairwiseMatrix[0][1]).toBe(2);
+        expect(results.pairwiseMatrix[1][0]).toBe(2);
+        expect(results.pairwiseMatrix[0][2]).toBe(2);
+        expect(results.pairwiseMatrix[2][0]).toBe(2);
+
+        // Cap opció té victòries Schulze
+        expect(results.ranking.every(r => r.pairwiseWins === 0)).toBe(true);
+
+        // La primera de la llista és l'opció 0 (menor índex), però la UI ha de mostrar "empat"
+        expect(results.ranking[0].optionId).toBe(0);
+        expect(results.ranking[0].firstChoiceVotes).toBe(0);
+    });
+
+    it('exposa la matriu pairwise correctament', () => {
+        // Cas simple: 3 opcions, 1 vot cadascuna com a primera
+        const paperetes = [
+            [0, 1, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+        ];
+
+        const results = computeElectionResults(pid, paperetes, 3);
+
+        // d[i][j] + d[j][i] = nombre de votants (cada votant té exactament 1 preferència per parella)
+        expect(results.pairwiseMatrix[0][1] + results.pairwiseMatrix[1][0]).toBe(3);
+        expect(results.pairwiseMatrix[0][2] + results.pairwiseMatrix[2][0]).toBe(3);
+        expect(results.pairwiseMatrix[1][2] + results.pairwiseMatrix[2][1]).toBe(3);
+        expect(results.pairwiseMatrix.length).toBe(3);
     });
 });

--- a/client/src/domain/electionResults.ts
+++ b/client/src/domain/electionResults.ts
@@ -1,17 +1,21 @@
 import type {ProposalId} from './proposal';
 
-export interface OptionResult {
+interface OptionResult {
     /** Option index, matching `ProposalOption.id`. */
     optionId: number;
     firstChoiceVotes: number;
     /** 0 = winner, ties broken deterministically by option index. */
     finalRank: number;
+    /** How many other options this option defeats in pairwise comparisons. */
+    pairwiseWins: number;
 }
 
 export interface ElectionResults {
     proposalId: ProposalId;
     ranking: OptionResult[];
     totalVoters: number;
+    /** d[i][j] = number of voters who prefer option i over option j. */
+    pairwiseMatrix: number[][];
 }
 
 /**
@@ -23,7 +27,7 @@ export interface ElectionResults {
  */
 export function computeElectionResults(proposalId: ProposalId, ballots: number[][], optionCount: number): ElectionResults {
     if (ballots.length === 0 || optionCount === 0)
-        return {proposalId, ranking: [], totalVoters: 0};
+        return {proposalId, ranking: [], totalVoters: 0, pairwiseMatrix: []};
 
     const d: number[][] = Array.from({length: optionCount}, () =>
         new Array(optionCount).fill(0)
@@ -78,11 +82,12 @@ export function computeElectionResults(proposalId: ProposalId, ballots: number[]
         if (ballot.length > 0 && ballot[0] < optionCount)
             firstChoiceCounts[ballot[0]]++;
 
-    const ranking: OptionResult[] = wins.map(({optionId}, rank) => ({
+    const ranking: OptionResult[] = wins.map(({optionId, wins: winsCount}, rank) => ({
         optionId,
         firstChoiceVotes: firstChoiceCounts[optionId],
         finalRank: rank,
+        pairwiseWins: winsCount,
     }));
 
-    return {proposalId, ranking, totalVoters: ballots.length};
+    return {proposalId, ranking, totalVoters: ballots.length, pairwiseMatrix: d};
 }

--- a/client/src/pages/ResultsPage.tsx
+++ b/client/src/pages/ResultsPage.tsx
@@ -1,7 +1,7 @@
 import {m} from 'framer-motion';
 import {useTranslation} from 'react-i18next';
 import {useLoaderData, useNavigate} from 'react-router-dom';
-import {ArrowLeft, Radio, RefreshCw, Trophy, Users} from 'lucide-react';
+import {ArrowLeft, Radio, RefreshCw, Users} from 'lucide-react';
 
 import {useQuery} from '@tanstack/react-query';
 import {proposalQueries, votingQueries} from '@/algorand/queries';
@@ -9,6 +9,7 @@ import {proposalQueries, votingQueries} from '@/algorand/queries';
 import type {ProposalId} from "@/domain";
 
 import {VerificationPanel} from '@/components/results/VerificationPanel';
+import {ClosedResults} from "@/components/results/ClosedResults";
 
 import {formatDatetime} from '@/utils/date';
 
@@ -36,9 +37,6 @@ export function ResultsPage() {
         enabled: isClosed
     });
 
-    const results = electionResults?.ranking ?? [];
-    const totalVoters = electionResults?.totalVoters ?? 0;
-
     if (isPending) {
         return (
             <div className="mx-auto max-w-4xl px-6 py-14">
@@ -63,7 +61,7 @@ export function ResultsPage() {
         );
     }
 
-    const displayVoters = isClosed ? totalVoters : voterCount;
+    const displayVoters = isClosed ? (electionResults?.totalVoters ?? 0) : voterCount;
 
     return (
         <div className="mx-auto max-w-4xl px-6 py-14">
@@ -82,23 +80,27 @@ export function ResultsPage() {
                 <h1 className="font-display text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
                     {t('vote.results.title')}
                 </h1>
+
                 {isLive && (
                     <span
-                        className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-500">
+                        className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-500"
+                    >
                         <Radio size={11} className="animate-pulse"/> {t('common.live')}
                     </span>
                 )}
             </div>
 
             <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-muted">
-                <span>{formatDatetime(proposal.startDate, locale)} → {formatDatetime(proposal.endDate, locale)}</span>
+                <span>
+                    {formatDatetime(proposal.startDate, locale)} → {formatDatetime(proposal.endDate, locale)}
+                </span>
+
                 <span className="inline-flex items-center gap-1.5">
                     <Users size={13}/>
                     {t('vote.results.voters', {count: displayVoters})}
                 </span>
             </div>
 
-            {/* ── Election in progress ── */}
             {isLive && (
                 <m.div
                     initial={{opacity: 0, y: 16}}
@@ -125,137 +127,19 @@ export function ResultsPage() {
                 </m.div>
             )}
 
-            {/* ── Final results (closed) ── */}
             {isClosed && (
-                <>
-                    {resultsLoading && (
-                        <div className="mt-10 space-y-3">
-                            {['rs-a', 'rs-b', 'rs-c'].map((k) => (
-                                <div key={k} className="h-16 animate-pulse rounded-2xl bg-surface"/>
-                            ))}
-                        </div>
-                    )}
-
-                    {resultsError && <p className="mt-10 text-center text-sm text-muted">{resultsError.message}</p>}
-
-                    {!resultsLoading && !resultsError && results.length === 0 && (
-                        <div
-                            className="mt-10 rounded-2xl border border-dashed border-border p-12 text-center text-muted">
-                            {t('results.no-votes')}
-                        </div>
-                    )}
-
-                    {!resultsLoading && results.length > 0 && (() => {
-                        const winner = results[0];
-                        const winnerOpt = proposal.options.find((o) => o.id === winner.optionId);
-                        const maxVotes = results[0].firstChoiceVotes || 1;
-
-                        return (
-                            <>
-                                {/* Winner card */}
-                                <m.div
-                                    initial={{opacity: 0, y: 20}}
-                                    animate={{opacity: 1, y: 0}}
-                                    transition={{duration: 0.5}}
-                                    className="relative mt-10 overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-primary/20 via-surface to-accent/20 p-8"
-                                >
-                                    <div className="absolute -right-20 -top-20 size-64 rounded-full bg-primary/20 blur-3xl"/>
-                                    <div className="relative flex flex-wrap items-center justify-between gap-6">
-                                        <div>
-                                            <div
-                                                className="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary"
-                                            >
-                                                <Trophy size={14}/> {t('results.winner')}
-                                            </div>
-                                            <h2 className="font-display text-3xl font-semibold text-fg sm:text-4xl">
-                                                {winnerOpt?.title}
-                                            </h2>
-                                        </div>
-
-                                        <div className="text-right">
-                                            <div className="text-xs font-semibold uppercase tracking-wider text-muted">
-                                                {t('results.first-choice-votes')}
-                                            </div>
-
-                                            <div className="font-display text-5xl font-bold tabular-nums text-fg">
-                                                {winner.firstChoiceVotes}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </m.div>
-
-                                {/* Full ranking */}
-                                <h3 className="mb-4 mt-12 text-xs font-semibold uppercase tracking-wider text-muted">
-                                    {t('results.ranking')}
-                                </h3>
-
-                                <ul className="space-y-3">
-                                    {results.map((r, i) => {
-                                        const opt = proposal.options.find(o =>
-                                            o.id === r.optionId
-                                        );
-
-                                        const widthPct = (r.firstChoiceVotes / maxVotes) * 100;
-
-                                        return (
-                                            <m.li
-                                                key={r.optionId}
-                                                initial={{opacity: 0, x: -10}}
-                                                animate={{opacity: 1, x: 0}}
-                                                transition={{duration: 0.4, delay: i * 0.05}}
-                                                className="relative overflow-hidden rounded-2xl border border-border bg-surface p-4"
-                                            >
-                                                <div className="relative flex items-center gap-4">
-                                                    <div
-                                                        className={`flex size-10 shrink-0 items-center justify-center rounded-full font-display text-sm font-bold ${
-                                                            i === 0
-                                                                ? 'bg-gradient-to-br from-primary to-accent text-primary-fg'
-                                                                : 'bg-primary/10 text-primary'
-                                                        }`}
-                                                    >
-                                                        {i + 1}
-                                                    </div>
-                                                    <div className="min-w-0 flex-1">
-                                                        <div className="flex items-center justify-between gap-2">
-                                                            <span className="truncate text-sm font-semibold text-fg">
-                                                                {opt?.title}
-                                                            </span>
-
-                                                            <span className="tabular-nums text-sm text-muted">
-                                                                {r.firstChoiceVotes} {t('results.first-choice-short')}
-                                                            </span>
-                                                        </div>
-                                                        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-border">
-                                                            <m.div
-                                                                initial={{width: 0}}
-                                                                animate={{width: `${widthPct}%`}}
-                                                                transition={{
-                                                                    duration: 0.8,
-                                                                    delay: 0.2 + i * 0.08,
-                                                                    ease: 'easeOut'
-                                                                }}
-                                                                className={`h-full rounded-full ${
-                                                                    i === 0 ? 'bg-gradient-to-r from-primary to-accent' : 'bg-primary/60'
-                                                                }`}
-                                                            />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </m.li>
-                                        );
-                                    })}
-                                </ul>
-
-                                <p className="mt-4 text-center text-xs text-muted">
-                                    {t('results.schulze-note')}
-                                </p>
-                            </>
-                        );
-                    })()}
-                </>
+                <ClosedResults
+                    proposal={proposal}
+                    electionResults={electionResults}
+                    resultsLoading={resultsLoading}
+                    resultsError={resultsError}
+                />
             )}
 
-            <VerificationPanel/>
+            <VerificationPanel
+                proposalId={id}
+                options={proposal.options}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Descripció del canvi

La pàgina de resultats ara mostra de forma transparent com s'ha decidit el guanyador de cada votació pel mètode de Schulze.

Per cada parella de candidats, els votants poden veure quants vots va obtenir cada opció quan s'enfrontaven directament. Aquesta informació s'agrupa en una graella de duels que permet entendre per quin motiu una opció ha quedat per davant d'una altra, més enllà del recompte de primeres preferències.

A més, quan dues opcions empaten en el nombre de duels guanyats, la pàgina ja no mostra un guanyador fals: informa explícitament de l'empat i suggereix obrir una nova proposta per trencar-lo.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #139 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal