### PR TITLE
feat(client): verificació on-chain del vot per adreça d'Algorand

### DIFF
--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -22,7 +22,8 @@ import {
     hasApprovalVoted,
     hasElectionVoted,
     getElectionVoterCount,
-    getElectionBallots
+    getElectionBallots,
+    getElectionBallotForVoter,
 } from "./voting";
 
 import {mapToOrganization, mapToProposal} from './mappers';
@@ -44,7 +45,7 @@ async function fetchOrganizations(): Promise<Organization[]> {
     return results.filter((o): o is Organization => o !== null);
 }
 
-async function fetchCensusMembers(orgId: OrganizationId): Promise<string[]> {
+async function fetchCensusMembers(orgId: OrganizationId): Promise<Address[]> {
     return getCensusMembers(orgId);
 }
 
@@ -151,5 +152,12 @@ export const votingQueries = {
     electionResults: (proposalId: ProposalId, numOptions: number) => queryOptions({
         queryKey: queryKeys.voting.electionResults(proposalId),
         queryFn: () => fetchElectionResults(proposalId, numOptions),
-    })
+    }),
+    electionBallotForVoter: (address: Address, proposalId: ProposalId) => queryOptions({
+        queryKey: queryKeys.voting.electionBallotForVoter(address, proposalId),
+        queryFn: () => getElectionBallotForVoter(address, proposalId),
+        enabled: Boolean(address),
+        retry: false,
+        staleTime: 30_000,
+    }),
 }

--- a/client/src/algorand/queryKeys.ts
+++ b/client/src/algorand/queryKeys.ts
@@ -18,7 +18,8 @@ export const queryKeys = {
         approvalVoted: (address: Address, proposalId: ProposalId) => ['voting', 'approval', address, proposalId] as const,
         electionVoted: (address: Address, proposalId: ProposalId) => ['voting', 'election', address, proposalId] as const,
         electionVoterCount: (proposalId: ProposalId) => ['election', 'voterCount', proposalId] as const,
-        electionResults: (proposalId: ProposalId) => ['election', 'results', proposalId] as const
+        electionResults: (proposalId: ProposalId) => ['election', 'results', proposalId] as const,
+        electionBallotForVoter: (address: Address, proposalId: ProposalId) => ['voting', 'ballot', address, proposalId] as const
     },
     electionPrefix: ['election'] as const
 }

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -125,6 +125,16 @@ export async function getElectionBallots(proposalId: ProposalId): Promise<number
     }
 }
 
+export async function getElectionBallotForVoter(address: Address, proposalId: ProposalId): Promise<number[] | null> {
+    try {
+        const key = electionBallotKey(address, proposalId);
+        const box = await algodClient.getApplicationBoxByName(APP_ID, key).do();
+        return decodePreferenceOrder(box.value);
+    } catch {
+        return null;
+    }
+}
+
 function decodePreferenceOrder(data: Uint8Array): number[] {
     const type = algosdk.ABIType.from('uint8[]');
     const decoded = type.decode(data) as bigint[];

--- a/client/src/components/results/VerificationPanel.tsx
+++ b/client/src/components/results/VerificationPanel.tsx
@@ -1,15 +1,38 @@
 import {useState} from 'react';
 import {m} from 'framer-motion';
 import {useTranslation} from 'react-i18next';
-import {ShieldCheck, BadgeCheck} from 'lucide-react';
+import {ShieldCheck, BadgeCheck, AlertCircle, Loader2} from 'lucide-react';
+
+import type {Address, ProposalId, ProposalOption} from '@/domain';
+
+import {useQuery} from '@tanstack/react-query';
+import {votingQueries} from '@/algorand/queries';
 
 import {Button} from '@/components/ui/Button';
 
-export function VerificationPanel() {
+interface VerificationPanelProps {
+    proposalId: ProposalId;
+    options: ProposalOption[];
+}
+
+export function VerificationPanel({proposalId, options}: VerificationPanelProps) {
     const {t} = useTranslation();
 
-    const [value, setValue] = useState('');
-    const [verified, setVerified] = useState(false);
+    const [input, setInput] = useState('');
+    const [submittedAddress, setSubmittedAddress] = useState('');
+
+    const {data: ballot, isFetching, isError} = useQuery({
+        ...votingQueries.electionBallotForVoter(submittedAddress as Address, proposalId),
+        enabled: Boolean(submittedAddress),
+    });
+
+    const handleVerify = () => {
+        const trimmed = input.trim();
+        if (trimmed) setSubmittedAddress(trimmed);
+    };
+
+    const hasResult = Boolean(submittedAddress) && !isFetching;
+    const voted = hasResult && Array.isArray(ballot);
 
     return (
         <div className="mt-14 rounded-3xl border border-border bg-elevated p-6">
@@ -26,34 +49,78 @@ export function VerificationPanel() {
 
             <div className="flex flex-col gap-3 sm:flex-row">
                 <input
-                    value={value}
+                    value={input}
                     onChange={(e) => {
-                        setValue(e.target.value);
-                        setVerified(false);
+                        setInput(e.target.value);
+                        setSubmittedAddress('');
                     }}
+                    onKeyDown={(e) => e.key === 'Enter' && handleVerify()}
                     placeholder={t('results.verify.placeholder')}
                     className="h-11 flex-1 rounded-full border border-border bg-surface px-5 font-mono text-sm text-fg placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
                 />
-                <Button onClick={() => setVerified(Boolean(value.trim()))}>
+                <Button onClick={handleVerify} disabled={isFetching}>
+                    {isFetching && <Loader2 size={14} className="animate-spin"/>}
                     {t('results.verify.button')}
                 </Button>
             </div>
 
-            {verified && (
+            {hasResult && !isError && voted && (
                 <m.div
                     initial={{opacity: 0, y: 8}}
                     animate={{opacity: 1, y: 0}}
-                    className="mt-5 flex items-start gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4"
+                    className="mt-5 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4"
                 >
-                    <BadgeCheck className="mt-0.5 shrink-0 text-emerald-500" size={18}/>
-                    <div>
-                        <div className="text-sm font-semibold text-emerald-500">
-                            {t('results.verify.success')}
+                    <div className="flex items-start gap-3">
+                        <BadgeCheck className="mt-0.5 shrink-0 text-emerald-500" size={18}/>
+                        <div className="flex-1">
+                            <div className="text-sm font-semibold text-emerald-500">
+                                {t('results.verify.success')}
+                            </div>
+                            <div className="mt-3">
+                                <div className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted">
+                                    {t('results.verify.ranked')}
+                                </div>
+                                <ol className="space-y-1">
+                                    {ballot.map((optionId, i) => {
+                                        const opt = options.find((o) => o.id === optionId);
+                                        return (
+                                            <li key={optionId} className="flex items-baseline gap-2 text-xs text-fg">
+                                                <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 font-bold leading-none text-emerald-400">
+                                                    {i + 1}
+                                                </span>
+                                                {opt?.title ?? `Option ${optionId}`}
+                                            </li>
+                                        );
+                                    })}
+                                </ol>
+                            </div>
                         </div>
+                    </div>
+                </m.div>
+            )}
 
-                        <div className="mt-0.5 text-xs text-muted">
-                            {t('results.verify.ranked')} {value}
-                        </div>
+            {hasResult && !isError && !voted && (
+                <m.div
+                    initial={{opacity: 0, y: 8}}
+                    animate={{opacity: 1, y: 0}}
+                    className="mt-5 flex items-start gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4"
+                >
+                    <AlertCircle className="mt-0.5 shrink-0 text-amber-400" size={18}/>
+                    <div className="text-sm text-amber-400">
+                        {t('results.verify.not-voted')}
+                    </div>
+                </m.div>
+            )}
+
+            {isError && (
+                <m.div
+                    initial={{opacity: 0, y: 8}}
+                    animate={{opacity: 1, y: 0}}
+                    className="mt-5 flex items-start gap-3 rounded-2xl border border-rose-500/30 bg-rose-500/10 p-4"
+                >
+                    <AlertCircle className="mt-0.5 shrink-0 text-rose-400" size={18}/>
+                    <div className="text-sm text-rose-400">
+                        {t('errors.network')}
                     </div>
                 </m.div>
             )}


### PR DESCRIPTION
## Descripció del canvi

Qualsevol persona pot ara comprovar, directament a la pàgina de resultats, si una adreça d'Algorand ha participat en una votació i, si és el cas, veure l'ordre de preferències que va registrar a la cadena.

Quan s'introdueix una adreça que ha votat, el panell mostra la llista ordenada d'opcions tal com van quedar enregistrades al contracte. Si l'adreça no ha participat, s'informa explícitament que no consta cap vot per a aquella adreça. En cas d'error de xarxa, es mostra un avís diferenciat.

La verificació es fa per adreça en lloc de per ID de transacció, ja que el contracte ja indexa les paperetes per adreça i això evita haver d'emmagatzemar cap identificador addicional.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #145

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal