### PR TITLE
feat(client): dependències happy-dom i reat-testing-library i la seva configuració

### DIFF
--- a/client/bunfig.toml
+++ b/client/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./happydom.ts"]

--- a/client/happydom.ts
+++ b/client/happydom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/client/package.json
+++ b/client/package.json
@@ -31,11 +31,14 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.9.0",
+    "@testing-library/react": "^16.3.2",
     "@types/bun": "^1.3.13",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "6.0.2",
     "autoprefixer": "^10.4.19",
+    "happy-dom": "^20.9.0",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.5.3",


### PR DESCRIPTION
## Descripció del canvi

S'han afegit `happy-dom` i `react-testing-library` per tenir la capacitat de testejar components del front-end. 

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [x] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #468 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
