### PR TITLE
feat(docker): serveis Hardhat i ancoratge al docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -27,3 +27,21 @@ INDEXER_PORT=8980
 
 # ── Explorador de transaccions Algorand ───────────────────────────────────────
 VITE_LORA_BASE=https://lora.algokit.io/localnet/transaction
+
+# ── Node Ethereum (Hardhat local) ─────────────────────────────────────────────
+# Port JSON-RPC exposat al host
+ETH_RPC_PORT=8545
+
+# Timeouts del NotaryContract
+ETH_GAS_LIMIT=200000
+ETH_TX_TIMEOUT=60
+
+# ── Claus privades dels nodes universitaris (comptes deterministes Hardhat) ──
+# Aquestes són les claus públiques de test de Hardhat (mnemonic per defecte
+# "test test test ... junk"), no usar mai a mainnet.
+# Account #1
+UIB_ETH_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+# Account #2
+UPC_ETH_PRIVATE_KEY=0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
+# Account #3
+UAB_ETH_PRIVATE_KEY=0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@
 #   algod conté DOS nodes interns (lead:8080 + follower:8081).
 #   conduit-localnet llegeix deltes d'estat del follower via 'localnet_algod'.
 #   indexer serveix l'API de cerca sobre postgres.
+#
+# Arquitectura Ethereum / ancoratge:
+#   hardhat exposa un node JSON-RPC local (port ${ETH_RPC_PORT}).
+#   ethereum-deploy compila i desplega NotaryContract, registra les 3
+#   universitats com a submitters i escriu NOTARY_CONTRACT_ADDRESS al
+#   volum compartit 'shared-state'.
+#   anchoring és un contenidor en repòs amb deps web3+algosdk; valida
+#   connectivitat a l'inici i resta disponible per a 'docker compose exec'.
 
 services:
   algod:
@@ -55,6 +63,7 @@ services:
     volumes:
       - ./voting-contract:/workspace
       - ./client:/client-out
+      - shared-state:/shared
       - uv-cache:/root/.cache/uv
     environment:
       ALGOD_SERVER: "http://${ALGOD_HOST}"
@@ -84,9 +93,116 @@ services:
         fi
         echo "[contract-deploy] APP_ID=$$APP_ID — writing /client-out/.env.local"
         echo "VITE_APP_ID=$$APP_ID" > /client-out/.env.local
+        echo "[contract-deploy] writing /shared/algorand.env"
+        echo "DEMOCHAIN_APP_ID=$$APP_ID" > /shared/algorand.env
     depends_on:
       algod:
         condition: service_healthy
+    restart: "no"
+
+  hardhat:
+    image: node:20-bookworm-slim
+    working_dir: /workspace
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        if [ ! -d node_modules ] || [ ! -x node_modules/.bin/hardhat ]; then
+          echo "[hardhat] npm install"
+          npm install --no-audit --no-fund
+        fi
+        echo "[hardhat] starting node on 0.0.0.0:8545"
+        exec npx --no-install hardhat node --hostname 0.0.0.0 --port 8545
+    volumes:
+      - ./network/ethereum:/workspace
+      - hardhat-node-modules:/workspace/node_modules
+    ports:
+      - "${ETH_RPC_PORT}:8545"
+    healthcheck:
+      test: ["CMD", "node", "/workspace/healthcheck.js"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+
+  ethereum-deploy:
+    image: node:20-bookworm-slim
+    working_dir: /workspace
+    volumes:
+      - ./network/ethereum:/workspace
+      - shared-state:/shared
+      - hardhat-node-modules:/workspace/node_modules
+    environment:
+      ETHEREUM_LOCALHOST_URL: "http://hardhat:8545"
+      UIB_ETH_PRIVATE_KEY: "${UIB_ETH_PRIVATE_KEY}"
+      UPC_ETH_PRIVATE_KEY: "${UPC_ETH_PRIVATE_KEY}"
+      UAB_ETH_PRIVATE_KEY: "${UAB_ETH_PRIVATE_KEY}"
+      SHARED_DIR: /shared
+    depends_on:
+      hardhat:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        echo "[ethereum-deploy] hardhat compile"
+        npx --no-install hardhat compile
+        echo "[ethereum-deploy] deploying NotaryContract + registering universities"
+        npx --no-install hardhat run scripts/deploy_localnet.js --network localhost
+    restart: "no"
+
+  anchoring:
+    image: python:3.12-slim
+    working_dir: /workspace
+    volumes:
+      - ./network:/workspace/network
+      - shared-state:/shared
+      - anchoring-pip-cache:/root/.cache/pip
+    environment:
+      ALGOD_SERVER: "http://${ALGOD_HOST}"
+      ALGOD_PORT: "${ALGOD_CONTAINER_PORT}"
+      ALGOD_TOKEN: "${ALGO_TOKEN}"
+      INDEXER_SERVER: "http://indexer"
+      INDEXER_PORT: "8980"
+      ETHEREUM_RPC_URL: "http://hardhat:8545"
+      ETH_GAS_LIMIT: "${ETH_GAS_LIMIT}"
+      ETH_TX_TIMEOUT: "${ETH_TX_TIMEOUT}"
+      UIB_ETH_PRIVATE_KEY: "${UIB_ETH_PRIVATE_KEY}"
+      UPC_ETH_PRIVATE_KEY: "${UPC_ETH_PRIVATE_KEY}"
+      UAB_ETH_PRIVATE_KEY: "${UAB_ETH_PRIVATE_KEY}"
+      PYTHONPATH: /workspace
+    depends_on:
+      algod:
+        condition: service_healthy
+      hardhat:
+        condition: service_healthy
+      contract-deploy:
+        condition: service_completed_successfully
+      ethereum-deploy:
+        condition: service_completed_successfully
+    command:
+      - bash
+      - -c
+      - |
+        set -eu
+        echo "[anchoring] installing deps"
+        pip install --quiet --no-input \
+          'py-algorand-sdk>=2.7,<3' \
+          'web3>=7.0,<8' \
+          'eth-account>=0.13' \
+          'python-dotenv>=1.0,<2'
+        if [ -f /shared/algorand.env ]; then
+          export $$(cat /shared/algorand.env | xargs)
+        fi
+        if [ -f /shared/ethereum.env ]; then
+          export $$(cat /shared/ethereum.env | xargs)
+        fi
+        echo "[anchoring] running smoke test"
+        python /workspace/network/anchoring/smoke.py
+        echo "[anchoring] ready — 'docker compose exec anchoring ...' to run anchoring ops"
+        exec tail -f /dev/null
     restart: "no"
 
   indexer-db:
@@ -164,3 +280,6 @@ volumes:
   conduit-data:
   client-node-modules:
   uv-cache:
+  hardhat-node-modules:
+  anchoring-pip-cache:
+  shared-state:

--- a/network/anchoring/smoke.py
+++ b/network/anchoring/smoke.py
@@ -1,0 +1,127 @@
+"""Smoke test que verifica la connectivitat del servei d'ancoratge.
+
+Comprova:
+  1. Connexió a algod i lectura de l'estat
+  2. Connexió al node Ethereum (Hardhat local)
+  3. NotaryContract desplegat amb el nombre esperat d'universitats blanquejades
+  4. Adreces Ethereum de UIB/UPC/UAB efectivament a la whitelist
+
+Es crida un cop a l'inici del contenidor 'anchoring' del docker-compose; si
+totes les comprovacions passen, deixa el contenidor en repòs perquè es pugui
+operar amb 'docker compose exec anchoring ...'.
+"""
+
+import logging
+import os
+import sys
+
+from algosdk.v2client.algod import AlgodClient
+from eth_account import Account
+from web3 import Web3
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[anchoring-smoke] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def check_algod() -> None:
+    server = _env("ALGOD_SERVER", "http://algod")
+    port = _env("ALGOD_PORT", "8080")
+    token = _env("ALGOD_TOKEN", "a" * 64)
+    url = f"{server}:{port}" if not server.endswith(f":{port}") else server
+    logger.info("connecting to algod at %s", url)
+    client = AlgodClient(token, url)
+    status = client.status()
+    logger.info("algod ok — last_round=%s", status.get("last-round"))
+
+
+def check_app_id() -> int | None:
+    app_id_str = _env("DEMOCHAIN_APP_ID", "").strip()
+    if not app_id_str:
+        logger.warning("DEMOCHAIN_APP_ID not set (contract-deploy may not have finished)")
+        return None
+    try:
+        app_id = int(app_id_str)
+    except ValueError:
+        logger.error("DEMOCHAIN_APP_ID is not a number: %r", app_id_str)
+        return None
+    logger.info("DEMOCHAIN_APP_ID=%d", app_id)
+    return app_id
+
+
+def check_ethereum() -> Web3:
+    rpc = _env("ETHEREUM_RPC_URL", "http://hardhat:8545")
+    logger.info("connecting to ethereum at %s", rpc)
+    w3 = Web3(Web3.HTTPProvider(rpc))
+    if not w3.is_connected():
+        raise RuntimeError(f"cannot connect to {rpc}")
+    logger.info("ethereum ok — chain_id=%s, block=%s", w3.eth.chain_id, w3.eth.block_number)
+    return w3
+
+
+def check_notary_contract(w3: Web3) -> None:
+    address = _env("NOTARY_CONTRACT_ADDRESS", "").strip()
+    if not address:
+        raise RuntimeError("NOTARY_CONTRACT_ADDRESS not set")
+    address = Web3.to_checksum_address(address)
+    abi = [
+        {
+            "inputs": [],
+            "name": "universityCount",
+            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [],
+            "name": "globalK",
+            "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+        {
+            "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+            "name": "whitelist",
+            "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+            "stateMutability": "view",
+            "type": "function",
+        },
+    ]
+    contract = w3.eth.contract(address=address, abi=abi)
+    count = contract.functions.universityCount().call()
+    k = contract.functions.globalK().call()
+    logger.info("NotaryContract @ %s — K-of-N = %d-of-%d", address, k, count)
+
+    for uni_id in ("UIB", "UPC", "UAB"):
+        key = _env(f"{uni_id}_ETH_PRIVATE_KEY", "").strip()
+        if not key:
+            logger.warning("%s_ETH_PRIVATE_KEY not set — skipping whitelist check", uni_id)
+            continue
+        addr = Account.from_key(key).address
+        ok = contract.functions.whitelist(addr).call()
+        logger.info("%s (%s) whitelisted=%s", uni_id, addr, ok)
+        if not ok:
+            raise RuntimeError(f"{uni_id} not in NotaryContract whitelist")
+
+
+def main() -> int:
+    try:
+        check_algod()
+        check_app_id()
+        w3 = check_ethereum()
+        check_notary_contract(w3)
+    except Exception as exc:
+        logger.error("smoke test FAILED: %s", exc)
+        return 1
+    logger.info("ALL CHECKS PASSED — anchoring service ready")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/network/ethereum/healthcheck.js
+++ b/network/ethereum/healthcheck.js
@@ -1,0 +1,15 @@
+fetch("http://localhost:8545", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1,
+  }),
+})
+  .then((r) => r.json())
+  .then((j) => {
+    if (!j.result) process.exit(1);
+  })
+  .catch(() => process.exit(1));

--- a/network/ethereum/scripts/deploy_localnet.js
+++ b/network/ethereum/scripts/deploy_localnet.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const path = require("path");
+const { ethers } = require("hardhat");
+
+const SHARED_DIR = process.env.SHARED_DIR || "/shared";
+
+async function main() {
+  const [admin] = await ethers.getSigners();
+  console.log("[deploy_localnet] admin:", admin.address);
+
+  const NotaryContract = await ethers.getContractFactory("NotaryContract");
+  const notary = await NotaryContract.deploy();
+  await notary.waitForDeployment();
+  const contractAddress = await notary.getAddress();
+  console.log("[deploy_localnet] NotaryContract deployed at:", contractAddress);
+
+  const universityKeys = [
+    { id: "UIB", key: process.env.UIB_ETH_PRIVATE_KEY },
+    { id: "UPC", key: process.env.UPC_ETH_PRIVATE_KEY },
+    { id: "UAB", key: process.env.UAB_ETH_PRIVATE_KEY },
+  ];
+
+  for (const uni of universityKeys) {
+    if (!uni.key) {
+      console.log(`[deploy_localnet] skipping ${uni.id}: no private key in env`);
+      continue;
+    }
+    const wallet = new ethers.Wallet(uni.key);
+    const tx = await notary.addUniversity(wallet.address);
+    await tx.wait();
+    console.log(`[deploy_localnet] addUniversity(${uni.id}=${wallet.address}) ok`);
+  }
+
+  const k = await notary.globalK();
+  const n = await notary.universityCount();
+  console.log(`[deploy_localnet] consensus K-of-N = ${k}-of-${n}`);
+
+  if (!fs.existsSync(SHARED_DIR)) {
+    fs.mkdirSync(SHARED_DIR, { recursive: true });
+  }
+  fs.writeFileSync(
+    path.join(SHARED_DIR, "ethereum.env"),
+    `NOTARY_CONTRACT_ADDRESS=${contractAddress}\n`,
+  );
+  console.log(`[deploy_localnet] wrote ${SHARED_DIR}/ethereum.env`);
+  console.log(`NOTARY_CONTRACT_ADDRESS=${contractAddress}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Descripció del canvi

Aquesta PR amplia el `docker-compose.yml` perquè `docker compose up` arrenqui també la cadena Ethereum local i el servei d'ancoratge, fins ara fora del Docker. Es completa l'entorn de desenvolupament: Algorand (algod, indexer, conduit) + client + contracte ARC4 + node Ethereum (Hardhat) + NotaryContract desplegat + servei d'ancoratge en repòs.

## Tipus de canvi

- [x] `feat` - Nova funcionalitat
- [ ] `fix` - Correcció d'error
- [ ] `docs` - Documentació
- [ ] `refactor` - Refactorització (no canvia funcionalitat)
- [ ] `test` - Tests
- [ ] `chore` - Manteniment, deps, CI

## Issues relacionades

Closes #537

## Serveis nous

- **`hardhat`**: `npx hardhat node --hostname 0.0.0.0 --port 8545` amb healthcheck (`network/ethereum/healthcheck.js`).
- **`ethereum-deploy`**: one-shot. Compila `NotaryContract.sol`, el desplega, registra UIB/UPC/UAB com a submitters (claus deterministes de Hardhat #1-3) i escriu `NOTARY_CONTRACT_ADDRESS` al volum compartit `shared-state`.
- **`anchoring`**: contenidor Python 3.12 amb `py-algorand-sdk` + `web3` + `eth-account`. Executa `network/anchoring/smoke.py` (verifica algod, Ethereum i la whitelist del NotaryContract) i queda en repòs per a `docker compose exec`.

## Canvis a serveis existents

- `contract-deploy` ara també escriu `DEMOCHAIN_APP_ID` al volum `shared-state` perquè anchoring el llegeixi (mantenint l'escriptura existent a `client/.env.local`).

## Fitxers nous

- `network/ethereum/healthcheck.js`
- `network/ethereum/scripts/deploy_localnet.js`
- `network/anchoring/smoke.py`

## Variables d'entorn noves (al `.env`)

- `ETH_RPC_PORT=8545`, `ETH_GAS_LIMIT=200000`, `ETH_TX_TIMEOUT=60`
- `UIB_ETH_PRIVATE_KEY`, `UPC_ETH_PRIVATE_KEY`, `UAB_ETH_PRIVATE_KEY` (comptes deterministes Hardhat, només per a localnet — no usar mai a mainnet)

## Verificació

Llançament del stack:

```
algod              Up (healthy)
hardhat            Up (healthy)
indexer-db         Up (healthy)
conduit            Up
indexer            Up
contract-deploy    Exited (0)
ethereum-deploy    Exited (0)
anchoring          Up
```

Smoke test del servei anchoring:

```
[anchoring-smoke] algod ok — last_round=4
[anchoring-smoke] DEMOCHAIN_APP_ID=1003
[anchoring-smoke] ethereum ok — chain_id=31337, block=8
[anchoring-smoke] NotaryContract @ 0xDc64...  — K-of-N = 2-of-3
[anchoring-smoke] UIB (0x7099...) whitelisted=True
[anchoring-smoke] UPC (0x3C44...) whitelisted=True
[anchoring-smoke] UAB (0x90F7...) whitelisted=True
[anchoring-smoke] ALL CHECKS PASSED — anchoring service ready
```

## Tests

- `poetry run pytest` (voting-contract): **59 passed**.
- `bun test` (client): **203 passed, 6 fail**.
  - Els 6 fails són tots de `governance-client.test.ts` amb error `election.not-started`. **Pre-existents a `dev`** (verificat fent stash de la branca i tornant a executar). El problema rau en `DevMode: true` del LocalNet: `Global.latest_timestamp` no avança entre transaccions, per la qual cosa la finestra de votació mai no comença. Es resoldrà en #538 (servei `chain-heartbeat`).
- `make lint`: passa sense errors.

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits
- [x] He executat `make lint` i passa sense errors
- [x] La documentació al capçal del `docker-compose.yml` s'ha actualitzat

🤖 Generated with [Claude Code](https://claude.com/claude-code)