### PR TITLE
feat(devops): servei chain-heartbeat per a LocalNet en DevMode

### DIFF
--- a/.env
+++ b/.env
@@ -45,3 +45,8 @@ UIB_ETH_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b
 UPC_ETH_PRIVATE_KEY=0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
 # Account #3
 UAB_ETH_PRIVATE_KEY=0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
+
+# ── Heartbeat del LocalNet (només per a la branca dev) ───────────────────────
+# Interval entre transaccions no-op que forcen la generació de blocs.
+# Mantén Global.latest_timestamp dins d'aquest interval del wall-clock.
+HEARTBEAT_INTERVAL_SEC=3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,14 @@
 #   volum compartit 'shared-state'.
 #   anchoring és un contenidor en repòs amb deps web3+algosdk; valida
 #   connectivitat a l'inici i resta disponible per a 'docker compose exec'.
+#
+# Heartbeat del LocalNet (només per a la branca dev):
+#   chain-heartbeat submiteix una PaymentTxn no-op cada
+#   HEARTBEAT_INTERVAL_SEC segons (per defecte 3) per forçar la generació
+#   de blocs i mantenir Global.latest_timestamp dins de N segons del
+#   wall-clock. Necessari perquè algod corre amb DevMode=true i, sense
+#   transaccions, el rellotge del consens es congela.
+#   A main, en canvi, s'usarà DevMode=false (consens real ~3.3s/bloc).
 
 services:
   algod:
@@ -246,6 +254,34 @@ services:
         condition: service_started
     restart: unless-stopped
 
+  chain-heartbeat:
+    image: python:3.12-slim
+    working_dir: /workspace
+    volumes:
+      - ./network/heartbeat:/workspace
+      - heartbeat-pip-cache:/root/.cache/pip
+    environment:
+      ALGOD_URL: "http://${ALGOD_HOST}:${ALGOD_CONTAINER_PORT}"
+      ALGO_TOKEN: "${ALGO_TOKEN}"
+      KMD_URL: "http://${ALGOD_HOST}:${KMD_CONTAINER_PORT}"
+      KMD_TOKEN: "${ALGO_TOKEN}"
+      KMD_WALLET_NAME: "${KMD_WALLET_NAME}"
+      KMD_WALLET_PASSWORD: "${KMD_WALLET_PASSWORD}"
+      HEARTBEAT_INTERVAL_SEC: "${HEARTBEAT_INTERVAL_SEC}"
+    command:
+      - bash
+      - -c
+      - |
+        set -eu
+        echo "[chain-heartbeat] installing deps"
+        pip install --quiet --no-input 'py-algorand-sdk>=2.7,<3'
+        echo "[chain-heartbeat] starting"
+        exec python /workspace/heartbeat.py
+    depends_on:
+      algod:
+        condition: service_healthy
+    restart: unless-stopped
+
   client:
     image: oven/bun:1.3
     working_dir: /app
@@ -283,3 +319,4 @@ volumes:
   hardhat-node-modules:
   anchoring-pip-cache:
   shared-state:
+  heartbeat-pip-cache:

--- a/network/heartbeat/heartbeat.py
+++ b/network/heartbeat/heartbeat.py
@@ -1,0 +1,102 @@
+"""Heartbeat per al LocalNet d'Algorand en DevMode.
+
+En DevMode, algod només mina un bloc nou quan rep una transacció. Això
+deixa `Global.latest_timestamp` congelat entre transaccions, i els
+asserts del contracte sobre finestres de votació (starting_date /
+ending_date) no es comporten com a producció.
+
+Aquest script submiteix periòdicament una `PaymentTxn` de 0 microAlgos
+amb el remitent enviant-se a sí mateix (no-op), cosa que força la
+creació d'un bloc i fa avançar `latest_timestamp` al wall-clock real.
+
+Cost: una min-fee per heartbeat (1000 microAlgos) per a un compte de
+gènesi amb saldo de ~4×10^15 microAlgos.
+"""
+
+import logging
+import os
+import time
+
+from algosdk import kmd, transaction
+from algosdk.v2client import algod
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[heartbeat] %(asctime)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+def _pick_funded_account(algod_client: algod.AlgodClient, addresses: list[str]) -> tuple[str, int]:
+    """Retorna l'adreça amb el saldo més alt de la llista."""
+    best_addr = ""
+    best_balance = -1
+    for addr in addresses:
+        try:
+            info = algod_client.account_info(addr)
+            bal = info.get("amount", 0)
+        except Exception:
+            continue
+        if bal > best_balance:
+            best_balance = bal
+            best_addr = addr
+    if not best_addr:
+        raise RuntimeError("no funded accounts found in wallet")
+    return best_addr, best_balance
+
+
+def main() -> None:
+    algod_url = _env("ALGOD_URL", "http://algod:8080")
+    algod_token = _env("ALGO_TOKEN", "a" * 64)
+    kmd_url = _env("KMD_URL", "http://algod:7833")
+    kmd_token = _env("KMD_TOKEN", algod_token)
+    wallet_name = _env("KMD_WALLET_NAME", "unencrypted-default-wallet")
+    wallet_password = _env("KMD_WALLET_PASSWORD", "")
+    interval = int(_env("HEARTBEAT_INTERVAL_SEC", "3"))
+
+    log.info("algod=%s kmd=%s wallet=%r interval=%ds", algod_url, kmd_url, wallet_name, interval)
+
+    algod_client = algod.AlgodClient(algod_token, algod_url)
+    kmd_client = kmd.KMDClient(kmd_token, kmd_url)
+
+    wallets = kmd_client.list_wallets()
+    wallet_id = next((w["id"] for w in wallets if w["name"] == wallet_name), None)
+    if not wallet_id:
+        available = [w["name"] for w in wallets]
+        raise RuntimeError(f"wallet {wallet_name!r} not found; available={available}")
+
+    handle = kmd_client.init_wallet_handle(wallet_id, wallet_password)
+    addresses = kmd_client.list_keys(handle)
+    sender, balance = _pick_funded_account(algod_client, addresses)
+    log.info("sender=%s balance=%d microAlgos", sender, balance)
+
+    consecutive_errors = 0
+    while True:
+        try:
+            params = algod_client.suggested_params()
+            note = f"hb-{int(time.time())}".encode()
+            txn = transaction.PaymentTxn(sender, params, sender, 0, note=note)
+            signed = kmd_client.sign_transaction(handle, wallet_password, txn)
+            tx_id = algod_client.send_transaction(signed)
+            status = algod_client.status()
+            log.info("tx=%s round=%d ts=%d", tx_id, status.get("last-round", -1), int(time.time()))
+            consecutive_errors = 0
+        except Exception as exc:
+            consecutive_errors += 1
+            log.warning("error (%d in a row): %s", consecutive_errors, exc)
+            if consecutive_errors >= 3:
+                log.info("reinitialising wallet handle")
+                try:
+                    handle = kmd_client.init_wallet_handle(wallet_id, wallet_password)
+                except Exception as e:
+                    log.error("handle re-init failed: %s", e)
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descripció del canvi

El LocalNet d'Algorand corre amb `DevMode: true` (vegeu `algod-network-template.json:12`). En DevMode, algod només mina un bloc nou quan rep una transacció, així que `Global.latest_timestamp` queda congelat entre txns. Això fa que els asserts del contracte sobre finestres de votació (`contract.py:192-193`) no s'avaluïn correctament i provoca falles intermitents als tests d'integració.

Aquest PR afegeix un servei `chain-heartbeat` que submiteix una `PaymentTxn` no-op cada N segons. Cada heartbeat força un bloc i fa avançar `latest_timestamp` al wall-clock.

**Aquesta configuració és específica de la branca `dev`.** A `main` s'usarà l'enfocament alternatiu de `DevMode: false` (consens real ~3.3 s/bloc, més fidel a producció) en una PR separada.

## Tipus de canvi

- [x] `feat` - Nova funcionalitat
- [ ] `fix` - Correcció d'error
- [ ] `docs` - Documentació
- [ ] `refactor` - Refactorització
- [ ] `test` - Tests
- [ ] `chore` - Manteniment, deps, CI

## Issues relacionades

Closes #538

## Fitxers nous

- `network/heartbeat/heartbeat.py` — bucle Python que es connecta a KMD, troba el compte amb més saldo a `unencrypted-default-wallet` i submiteix una PaymentTxn no-op cada `HEARTBEAT_INTERVAL_SEC` segons.

## Canvis al `docker-compose.yml`

- Nou servei `chain-heartbeat` (Python 3.12, depends_on `algod` healthy, restart unless-stopped).
- Nou volum `heartbeat-pip-cache`.
- Comentari al capçal explicant per què el servei existeix.

## Variables d'entorn noves (al `.env`)

- `HEARTBEAT_INTERVAL_SEC=3` — interval entre heartbeats.

## Verificació

### Avanç de blocs

Sortida del servei en marxa:

```
[heartbeat] sender=TKFCTGFWB7CJ7QP2QYWL4MYIEWYA7ZCT2CKF64JABM7QHPWTM2Q7WZBXAE balance=4000000000000000 microAlgos
[heartbeat] tx=D4SK...  round=1 ts=1779634589
[heartbeat] tx=PBHH...  round=2 ts=1779634592
[heartbeat] tx=NMAT...  round=3 ts=1779634595
[heartbeat] tx=LIPW...  round=4 ts=1779634598
[heartbeat] tx=5WF5...  round=5 ts=1779634601
[heartbeat] tx=FMDF...  round=6 ts=1779634605
[heartbeat] tx=7Z36...  round=7 ts=1779634608
```

Cada bloc està ~3 s després de l'anterior, i el `block.ts` està només 2 s darrere del wall-clock real.

### Tests

| Suite | Abans (sense heartbeat) | Després (amb heartbeat) |
|---|---|---|
| `bun test` (client) | 203 passed, **6 fail** | **209 passed, 0 fail** |
| `poetry run pytest` (contract) | 59 passed | 59 passed |
| `make lint` | ✅ | ✅ |

Les 6 falles de `governance-client.test.ts` (totes amb `election.not-started`) eren pre-existents a `dev` i ara queden resoltes pel heartbeat.

### Cost

Min-fee per heartbeat: **1 000 microAlgos**. Compte de gènesi utilitzat: saldo de **4 × 10¹⁵ microAlgos** — suficient per ~10¹² heartbeats (uns 100 anys de funcionament continu a 3 s/heartbeat).

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits
- [x] He executat `make lint` i passa sense errors
- [x] Tests del contracte i del client passen al 100 %
- [ ] _Pendent_: PR separat sobre `main` amb `DevMode: false` (alternativa per a producció).

🤖 Generated with [Claude Code](https://claude.com/claude-code)