### PR TITLE
feat(devops): MVP de desplegament distribuït a TestNet+Sepolia

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,38 @@
+# Plantilla d'entorn per a un node universitari (MVP distribuït).
+# Copiar a .env.prod i omplir amb les credencials reals.
+#
+#   cp .env.prod.example .env.prod
+#   docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+#
+# Les credencials sensibles (UNI_ETH_PRIVATE_KEY) MAI s'han de pujar al
+# repositori ni compartir per canals no segurs.
+
+# ── Identitat del node universitari ──────────────────────────────────────────
+# Identificador curt usat als logs (ex: uib, upc, uab).
+UNIVERSITY_ID=
+
+# ── Endpoint d'Algorand (TestNet per defecte, gratuït via AlgoNode) ──────────
+ALGOD_SERVER=https://testnet-api.algonode.cloud
+ALGOD_PORT=443
+ALGOD_TOKEN=
+
+# ID numèric del contracte Demochain desplegat a Algorand TestNet.
+# Distribuït per l'administrador després del 'algokit project deploy testnet'.
+DEMOCHAIN_APP_ID=
+
+# ── Endpoint d'Ethereum (Sepolia per defecte) ────────────────────────────────
+# Substituir <KEY> per la pròpia clau d'Infura/Alchemy.
+ETHEREUM_RPC_URL=https://sepolia.infura.io/v3/<KEY>
+
+# Adreça del NotaryContract desplegat a Sepolia.
+# Distribuïda per l'administrador després del deploy.
+NOTARY_CONTRACT_ADDRESS=
+
+# Clau privada de l'adreça Ethereum d'aquesta universitat (registrada amb
+# addUniversity al NotaryContract per l'administrador). Format: 0x...
+UNI_ETH_PRIVATE_KEY=
+
+# ── Paràmetres operatius (valors per defecte raonables) ──────────────────────
+POLL_INTERVAL_SEC=30
+ETH_GAS_LIMIT=200000
+ETH_TX_TIMEOUT=60

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules
 # Entorns locals
 .env.local
 .env.*.local
+.env.prod
 
 # Python
 __pycache__/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,50 @@
+# Demochain - desplegament per a universitats (MVP distribuït)
+#
+# Aquest fitxer és el que cada universitat aixeca al seu propi servidor.
+# Només arrenca el dimoni d'ancoratge, que polleja Algorand TestNet i
+# envia els hashes finals al NotaryContract desplegat a Sepolia (o a
+# qualsevol altra xarxa EVM si es canvia ETHEREUM_RPC_URL).
+#
+# Ús:
+#   1. Demanar les credencials a l'administrador (.env.prod amb DEMOCHAIN_APP_ID,
+#      NOTARY_CONTRACT_ADDRESS i UNI_ETH_PRIVATE_KEY assignada).
+#   2. Còpia .env.prod.example → .env.prod i omplir.
+#   3. docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+#   4. docker compose -f docker-compose.prod.yml logs -f anchoring
+
+services:
+  anchoring:
+    image: python:3.12-slim
+    working_dir: /workspace
+    volumes:
+      - ./network:/workspace/network
+      - anchoring-prod-pip-cache:/root/.cache/pip
+    environment:
+      UNIVERSITY_ID: "${UNIVERSITY_ID}"
+      ALGOD_SERVER: "${ALGOD_SERVER}"
+      ALGOD_PORT: "${ALGOD_PORT}"
+      ALGOD_TOKEN: "${ALGOD_TOKEN}"
+      DEMOCHAIN_APP_ID: "${DEMOCHAIN_APP_ID}"
+      ETHEREUM_RPC_URL: "${ETHEREUM_RPC_URL}"
+      NOTARY_CONTRACT_ADDRESS: "${NOTARY_CONTRACT_ADDRESS}"
+      UNI_ETH_PRIVATE_KEY: "${UNI_ETH_PRIVATE_KEY}"
+      POLL_INTERVAL_SEC: "${POLL_INTERVAL_SEC:-30}"
+      ETH_GAS_LIMIT: "${ETH_GAS_LIMIT:-200000}"
+      ETH_TX_TIMEOUT: "${ETH_TX_TIMEOUT:-60}"
+      PYTHONPATH: /workspace
+    command:
+      - bash
+      - -c
+      - |
+        set -eu
+        echo "[anchoring-prod] installing deps"
+        pip install --quiet --no-input \
+          'py-algorand-sdk>=2.7,<3' \
+          'web3>=7.0,<8' \
+          'eth-account>=0.13'
+        echo "[anchoring-prod] starting daemon"
+        exec python -m network.anchoring.daemon
+    restart: unless-stopped
+
+volumes:
+  anchoring-prod-pip-cache:

--- a/docs/research/deployment-prod-mvp.md
+++ b/docs/research/deployment-prod-mvp.md
@@ -1,0 +1,151 @@
+# MVP de desplegament distribuït (TestNet + Sepolia)
+
+Aquest document descriu com aixecar Demochain en una configuració distribuïda
+on cada universitat opera el seu propi servei d'ancoratge, contra Algorand
+TestNet i Sepolia. És el pas intermedi entre el LocalNet (tot en un host) i
+una hipotètica producció amb identitat federada i privacitat criptogràfica.
+
+## Arquitectura
+
+```
+Algorand TestNet                       Ethereum Sepolia
+   ┌───────────────┐                      ┌──────────────────┐
+   │  Demochain    │                      │  NotaryContract  │
+   │   APP_ID=N    │                      │     0xABC...     │
+   └───────┬───────┘                      └─────────▲────────┘
+           │ llegeix paperetes                      │ submitHash()
+           │                                        │
+   ┌───────┴────────┐  ┌────────────────┐  ┌────────┴──────────┐
+   │ Anchoring UIB  │  │ Anchoring UPC  │  │ Anchoring UAB     │
+   │  (servidor 1)  │  │  (servidor 2)  │  │  (servidor 3)     │
+   └────────────────┘  └────────────────┘  └───────────────────┘
+```
+
+Les universitats no es comuniquen entre elles directament: el consens
+*K-of-N* s'aconsegueix on-chain quan K nodes envien el mateix hash al
+NotaryContract.
+
+## Pas 1 — Desplegament dels contractes (administrador central)
+
+### Algorand TestNet
+
+Des de `voting-contract/projects/demochain/`:
+
+```bash
+# .env del repositori amb les credencials del creador a TestNet
+export ALGOD_SERVER=https://testnet-api.algonode.cloud
+export ALGOD_PORT=443
+export ALGOD_TOKEN=
+export DEPLOYER_MNEMONIC="..."   # 25 paraules d'un compte amb >1 ALGO
+
+algokit project deploy testnet
+```
+
+El log final inclou una línia `Deployed Demochain with app_id=<N>`. Aquest
+és el `DEMOCHAIN_APP_ID` que cal distribuir a cada universitat.
+
+### Sepolia
+
+Des de `network/ethereum/`:
+
+```bash
+export ETHEREUM_RPC_URL=https://sepolia.infura.io/v3/<KEY>
+export NOTARY_ADMIN_PRIVATE_KEY=0x...     # compte admin finançat amb ETH de Sepolia
+export UNIVERSITY_ADDRESSES=0xUIB...,0xUPC...,0xUAB...
+
+npx hardhat run scripts/deploy_testnet.js --network sepolia
+```
+
+El script:
+
+1. Desplega `NotaryContract` amb el compte admin com a propietari.
+2. Crida `addUniversity(addr)` per a cada adreça a `UNIVERSITY_ADDRESSES`.
+3. Imprimeix `NOTARY_CONTRACT_ADDRESS=0x...`.
+
+Cal distribuir aquesta adreça a cada universitat juntament amb el
+`DEMOCHAIN_APP_ID` d'Algorand.
+
+## Pas 2 — Generació de claus universitàries
+
+Cada universitat ha de generar la seva pròpia parella de claus Ethereum.
+Una manera segura amb `cast` (de Foundry):
+
+```bash
+cast wallet new
+# Address: 0x...
+# Private key: 0x...
+```
+
+L'**adreça** s'envia a l'administrador per ser registrada amb `addUniversity`.
+La **clau privada** es queda al servidor de la universitat i mai surt d'allà.
+
+L'administrador ha de finançar cada adreça amb una mica d'ETH de Sepolia
+(faucets de Cloudflare, Alchemy o Infura). Una transacció d'ancoratge costa
+aproximadament 100 000 gas; 0,01 ETH dura centenars d'eleccions.
+
+## Pas 3 — Aixecament del node per universitat
+
+Al servidor de la universitat (qualsevol Linux/macOS amb Docker):
+
+```bash
+git clone https://github.com/jvanyom/demochain.git
+cd demochain
+cp .env.prod.example .env.prod
+$EDITOR .env.prod   # omplir UNIVERSITY_ID, DEMOCHAIN_APP_ID,
+                    # NOTARY_CONTRACT_ADDRESS, ETHEREUM_RPC_URL,
+                    # UNI_ETH_PRIVATE_KEY
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml logs -f anchoring
+```
+
+El dimoni:
+
+- Es connecta a Algorand TestNet i n'enumera les propostes registrades.
+- Per a cada proposta amb `ending_date < now`, comprova si aquesta universitat
+  ja n'ha enviat el hash al NotaryContract (`getSubmission`).
+- Si no, calcula el hash determinista i el submiteix a Sepolia.
+- Dorm `POLL_INTERVAL_SEC` segons i torna a començar.
+
+La idempotència és nativa a la cadena: el dimoni es pot reiniciar en
+qualsevol moment sense risc de doble submissió.
+
+## Pas 4 — Verificació del consens
+
+Quan K dels N nodes han enviat el mateix hash, el NotaryContract emet l'event
+`ResultAnchored(electionId, resultHash, confirmations)` i marca l'elecció com
+ancorada. Es pot consultar per la web:
+
+```
+https://sepolia.etherscan.io/address/<NOTARY_CONTRACT_ADDRESS>#events
+```
+
+O programàticament:
+
+```javascript
+await notary.isElectionAnchored("proposta-42")  // true / false
+```
+
+## Limitacions conegudes de l'MVP
+
+- **Claus a env vars**: per a producció real caldria un HSM o un gestor
+  de secrets (AWS KMS, GCP Secret Manager, HashiCorp Vault).
+- **Admin únic del NotaryContract**: per a producció real caldria un
+  multi-sig (Gnosis Safe) amb un signant per universitat fundadora.
+- **Vots públics**: tothom pot veure qui ha votat què a Algorand TestNet.
+  La privacitat (ElGamal + zkSNARK) queda fora d'aquest MVP (vegeu E3/E4 al
+  *backlog*).
+- **Identitat per adreça**: el cens es manté per adreça Algorand sense
+  vinculació amb identitats institucionals. La integració amb un IdP
+  queda fora d'aquest MVP (vegeu E5/E6 al *backlog*).
+- **TestNet inestable**: Algorand TestNet pot rebre reinicis ocasionals
+  que invalidarien l'`APP_ID`. Caldria un redesplegament. Sepolia és
+  més estable però els fons de faucet poden ser costosos d'obtenir.
+
+## Resolució de problemes habituals
+
+| Símptoma | Causa probable |
+|----------|----------------|
+| `cannot reach algod` | Firewall corporatiu bloqueja `algonode.cloud` o endpoint mal escrit |
+| `admin account has 0 balance` (deploy Sepolia) | Falta finançar amb faucet abans del deploy |
+| `NotaryContract: not authorized` | L'adreça d'aquesta universitat no s'ha registrat amb `addUniversity` |
+| Cap proposta es detecta | El `DEMOCHAIN_APP_ID` apunta a un altre contracte o a una xarxa diferent |

--- a/network/anchoring/algorand_reader.py
+++ b/network/anchoring/algorand_reader.py
@@ -127,6 +127,34 @@ class AlgorandElectionReader:
             logger.error("Error llistant boxes de l'app %d: %s", self.app_id, exc)
             return []
 
+    def list_proposal_ids(self) -> list[int]:
+        """Retorna els IDs numèrics de totes les propostes registrades a l'app."""
+        prefix = BOX_PREFIX_PROPOSAL
+        prefix_len = len(prefix)
+        ids: list[int] = []
+        for box_name in self._list_boxes():
+            if not box_name.startswith(prefix):
+                continue
+            payload = box_name[prefix_len:]
+            if len(payload) != 8:
+                continue
+            (pid,) = struct.unpack(">Q", payload)
+            ids.append(pid)
+        return sorted(ids)
+
+    def read_proposal_window(self, proposal_id: int) -> Optional[tuple[int, int]]:
+        """Retorna (starting_date, ending_date) d'una proposta sense llegir les paperetes.
+
+        Optimitzat per al dimoni d'ancoratge: només descodifica les dues dates
+        del head del struct (bytes 46-62) per decidir si la proposta s'ha tancat.
+        """
+        raw = self._box_value(_proposal_box_key(proposal_id))
+        if raw is None or len(raw) < _PROPOSAL_HEAD_SIZE:
+            return None
+        starting_date = struct.unpack_from(">Q", raw, 46)[0]
+        ending_date = struct.unpack_from(">Q", raw, 54)[0]
+        return starting_date, ending_date
+
     def read_election_state(self, proposal_id: int) -> Optional[ElectionState]:
         """Llegeix l'estat complet d'una proposta: títol, opcions i totes les paperetes.
 

--- a/network/anchoring/daemon.py
+++ b/network/anchoring/daemon.py
@@ -1,0 +1,174 @@
+"""Dimoni d'ancoratge per a un node universitari.
+
+Polleja Algorand a la recerca de propostes tancades i, per a cada una,
+envia el hash al NotaryContract d'Ethereum si aquesta universitat
+encara no ho ha fet. La idempotència és cadena-nativa: abans de
+submitre es consulta `NotaryContract.getSubmission(electionId, my_addr)`
+i només s'envia si retorna zero. Això permet reiniciar el dimoni
+lliurement sense risc de doble submissió.
+
+Llançament típic (un cop per universitat):
+  docker compose -f docker-compose.prod.yml up -d
+
+Variables d'entorn requerides:
+  ALGOD_SERVER, ALGOD_PORT, ALGOD_TOKEN
+  DEMOCHAIN_APP_ID
+  ETHEREUM_RPC_URL
+  NOTARY_CONTRACT_ADDRESS
+  UNI_ETH_PRIVATE_KEY
+  UNIVERSITY_ID (per als logs)
+  POLL_INTERVAL_SEC (per defecte 30)
+"""
+
+import logging
+import os
+import sys
+import time
+
+from algosdk.v2client.algod import AlgodClient
+
+from .algorand_reader import AlgorandElectionReader
+from .anchoring_service import AnchoringService
+from .ethereum_submitter import EthereumSubmitter
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("anchoring.daemon")
+
+
+def _required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _build_algod() -> AlgodClient:
+    server = _required("ALGOD_SERVER")
+    port = os.environ.get("ALGOD_PORT", "").strip()
+    token = os.environ.get("ALGOD_TOKEN", "").strip()
+    url = f"{server}:{port}" if port else server
+    return AlgodClient(token, url)
+
+
+def _latest_block_timestamp(algod: AlgodClient) -> int:
+    status = algod.status()
+    last_round = status.get("last-round", 0)
+    if last_round == 0:
+        return 0
+    try:
+        block = algod.block_info(last_round)
+        return int(block.get("block", {}).get("ts", 0))
+    except Exception as exc:
+        logger.warning("error reading block %d timestamp: %s", last_round, exc)
+        return 0
+
+
+def _scan_once(
+    university_id: str,
+    reader: AlgorandElectionReader,
+    service: AnchoringService,
+    submitter: EthereumSubmitter,
+    algod: AlgodClient,
+) -> None:
+    now_chain = _latest_block_timestamp(algod)
+    if now_chain == 0:
+        logger.warning("could not read chain timestamp; skipping scan")
+        return
+
+    proposal_ids = reader.list_proposal_ids()
+    logger.info(
+        "scan: chain_ts=%d proposals=%d", now_chain, len(proposal_ids)
+    )
+
+    for pid in proposal_ids:
+        window = reader.read_proposal_window(pid)
+        if window is None:
+            continue
+        _, ending_date = window
+        if now_chain < ending_date:
+            continue  # voting window still open
+
+        election_id = f"proposta-{pid}"
+        if submitter.has_submitted(election_id):
+            logger.debug("[%s] %s ja submitida, ometent", university_id, election_id)
+            continue
+
+        logger.info("[%s] ancorant %s (proposal_id=%d)", university_id, election_id, pid)
+        try:
+            result = service.anchor(pid)
+        except Exception as exc:
+            logger.error("[%s] error ancorant %s: %s", university_id, election_id, exc)
+            continue
+        if result.submission and result.submission.success:
+            logger.info(
+                "[%s] %s submitida: tx=%s anchored=%s",
+                university_id,
+                election_id,
+                result.submission.tx_hash,
+                result.submission.anchored,
+            )
+        else:
+            err = result.submission.error if result.submission else "(no submitter)"
+            logger.error("[%s] submissió fallida per a %s: %s", university_id, election_id, err)
+
+
+def main() -> int:
+    try:
+        university_id = os.environ.get("UNIVERSITY_ID", "uni").strip() or "uni"
+        app_id = int(_required("DEMOCHAIN_APP_ID"))
+        rpc_url = _required("ETHEREUM_RPC_URL")
+        notary_address = _required("NOTARY_CONTRACT_ADDRESS")
+        private_key = _required("UNI_ETH_PRIVATE_KEY")
+        poll_interval = int(os.environ.get("POLL_INTERVAL_SEC", "30"))
+    except RuntimeError as exc:
+        logger.error("configuration error: %s", exc)
+        return 2
+
+    algod = _build_algod()
+    try:
+        status = algod.status()
+        logger.info(
+            "[%s] connected to algod, last_round=%s",
+            university_id,
+            status.get("last-round"),
+        )
+    except Exception as exc:
+        logger.error("cannot reach algod: %s", exc)
+        return 3
+
+    submitter = EthereumSubmitter(
+        rpc_url=rpc_url,
+        contract_address=notary_address,
+        private_key=private_key,
+    )
+    reader = AlgorandElectionReader(algod, app_id)
+    service = AnchoringService(
+        university_id=university_id,
+        algod_client=algod,
+        app_id=app_id,
+        eth_submitter=submitter,
+    )
+
+    logger.info(
+        "[%s] daemon ready: app_id=%d notary=%s submitter=%s interval=%ds",
+        university_id,
+        app_id,
+        notary_address,
+        submitter.account.address,
+        poll_interval,
+    )
+
+    while True:
+        try:
+            _scan_once(university_id, reader, service, submitter, algod)
+        except Exception as exc:
+            logger.exception("unexpected error during scan: %s", exc)
+        time.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/network/anchoring/ethereum_submitter.py
+++ b/network/anchoring/ethereum_submitter.py
@@ -122,6 +122,23 @@ class EthereumSubmitter:
         self.gas_limit = gas_limit
         self.tx_timeout = tx_timeout
 
+    def has_submitted(self, election_id: str) -> bool:
+        """Indica si aquest submitter ja ha enviat un hash per a l'elecció.
+
+        Utilitzat pel dimoni d'ancoratge per garantir idempotència sense
+        necessitat de cap estat local: la font de veritat és la cadena.
+        """
+        try:
+            stored = self.contract.functions.getSubmission(
+                election_id, self.account.address
+            ).call()
+        except Exception as exc:
+            logger.warning(
+                "Error consultant getSubmission per a '%s': %s", election_id, exc
+            )
+            return False
+        return stored != b"\x00" * 32
+
     def submit_hash(self, election_id: str, result_hash: bytes) -> SubmissionResult:
         """Envia el hash d'una proposta al NotaryContract.
 

--- a/network/anchoring/tests/test_algorand_reader.py
+++ b/network/anchoring/tests/test_algorand_reader.py
@@ -234,3 +234,35 @@ class TestAlgorandElectionReader:
         reader = self._make_reader({_proposal_box_key(1): prop_raw}, status_round=42)
         state = reader.read_election_state(1)
         assert state.block_round == 42
+
+    def test_list_proposal_ids_returns_sorted_ids(self):
+        prop_raw = build_proposal_raw("T", "D", ["A"])
+        boxes = {
+            _proposal_box_key(7): prop_raw,
+            _proposal_box_key(1): prop_raw,
+            _proposal_box_key(42): prop_raw,
+        }
+        reader = self._make_reader(boxes)
+        assert reader.list_proposal_ids() == [1, 7, 42]
+
+    def test_list_proposal_ids_ignores_ballot_boxes(self):
+        prop_raw = build_proposal_raw("T", "D", ["A"])
+        ballot_raw = struct.pack(">H", 1) + bytes([0])
+        boxes = {
+            _proposal_box_key(1): prop_raw,
+            _ballot_box_key(proposal_id=1, voter_address_bytes=bytes(32)): ballot_raw,
+        }
+        reader = self._make_reader(boxes)
+        assert reader.list_proposal_ids() == [1]
+
+    def test_read_proposal_window_returns_dates(self):
+        prop_raw = build_proposal_raw(
+            "T", "D", ["A"], start=1_700_000_000, end=1_700_086_400
+        )
+        reader = self._make_reader({_proposal_box_key(1): prop_raw})
+        window = reader.read_proposal_window(1)
+        assert window == (1_700_000_000, 1_700_086_400)
+
+    def test_read_proposal_window_returns_none_for_missing(self):
+        reader = self._make_reader({})
+        assert reader.read_proposal_window(99) is None

--- a/network/ethereum/scripts/deploy_testnet.js
+++ b/network/ethereum/scripts/deploy_testnet.js
@@ -1,0 +1,72 @@
+const fs = require("fs");
+const path = require("path");
+const { ethers, network } = require("hardhat");
+
+const SHARED_DIR = process.env.SHARED_DIR || "/shared";
+
+function parseUniversityAddresses(envValue) {
+  if (!envValue) return [];
+  return envValue
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+async function main() {
+  const [admin] = await ethers.getSigners();
+  console.log("[deploy_testnet] network:", network.name);
+  console.log("[deploy_testnet] admin:", admin.address);
+  const balance = await ethers.provider.getBalance(admin.address);
+  console.log("[deploy_testnet] admin balance:", ethers.formatEther(balance), "ETH");
+
+  if (balance === 0n) {
+    throw new Error(
+      "admin account has 0 balance; fund it from a faucet before deploying",
+    );
+  }
+
+  const NotaryContract = await ethers.getContractFactory("NotaryContract");
+  const notary = await NotaryContract.deploy();
+  await notary.waitForDeployment();
+  const contractAddress = await notary.getAddress();
+  console.log("[deploy_testnet] NotaryContract deployed at:", contractAddress);
+
+  const addresses = parseUniversityAddresses(process.env.UNIVERSITY_ADDRESSES);
+  if (addresses.length === 0) {
+    console.log(
+      "[deploy_testnet] UNIVERSITY_ADDRESSES not set; skipping addUniversity calls",
+    );
+    console.log(
+      "[deploy_testnet] call notary.addUniversity(<addr>) manually before each university can submit",
+    );
+  } else {
+    for (const addr of addresses) {
+      const checksummed = ethers.getAddress(addr);
+      const tx = await notary.addUniversity(checksummed);
+      await tx.wait();
+      console.log(`[deploy_testnet] addUniversity(${checksummed}) ok`);
+    }
+    const k = await notary.globalK();
+    const n = await notary.universityCount();
+    console.log(`[deploy_testnet] consensus K-of-N = ${k}-of-${n}`);
+  }
+
+  if (fs.existsSync(SHARED_DIR) && process.env.SKIP_SHARED_WRITE !== "1") {
+    fs.writeFileSync(
+      path.join(SHARED_DIR, "ethereum.env"),
+      `NOTARY_CONTRACT_ADDRESS=${contractAddress}\n`,
+    );
+    console.log(`[deploy_testnet] wrote ${SHARED_DIR}/ethereum.env`);
+  }
+
+  console.log(`\nNOTARY_CONTRACT_ADDRESS=${contractAddress}`);
+  console.log("\nDistribuir aquesta adreça a cada universitat juntament amb:");
+  console.log("  - DEMOCHAIN_APP_ID (de l'AlgoKit deploy a TestNet)");
+  console.log("  - ETHEREUM_RPC_URL (per defecte un endpoint de Sepolia)");
+  console.log("  - UNI_ETH_PRIVATE_KEY (la clau privada de la pròpia universitat)");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Descripció del canvi

Permet validar la hipòtesi central del projecte —que tres universitats geogràficament distribuïdes poden ancorar una elecció de manera independent al consens K-de-N— amb un MVP que apunta a Algorand TestNet i Sepolia en comptes de LocalNet+Hardhat.

Cada universitat aixeca al seu servidor un únic servei (\`docker compose -f docker-compose.prod.yml\`) que polleja Algorand i, quan detecta una proposta tancada, n'envia el hash al \`NotaryContract\` de Sepolia. Les universitats no es comuniquen entre elles: el consens K-de-N és cadena-natiu.

## Tipus de canvi

- [x] \`feat\` - Nova funcionalitat
- [ ] \`fix\` - Correcció d'error
- [ ] \`docs\` - Documentació
- [ ] \`refactor\` - Refactorització
- [ ] \`test\` - Tests
- [ ] \`chore\` - Manteniment, deps, CI

## Issues relacionades

Closes #541

## Fitxers nous

- **\`network/anchoring/daemon.py\`** — dimoni que polleja propostes tancades. Idempotència via \`NotaryContract.getSubmission(electionId, my_addr)\`, sense estat local.
- **\`network/ethereum/scripts/deploy_testnet.js\`** — desplegament del \`NotaryContract\` a Sepolia (o qualsevol RPC EVM), amb registre d'universitats per adreça via la variable \`UNIVERSITY_ADDRESSES\`.
- **\`docker-compose.prod.yml\`** — compose mínim amb només el servei d'ancoratge, env-driven.
- **\`.env.prod.example\`** — plantilla per a cada universitat (\`.env.prod\` ignorat per Git).
- **\`docs/research/deployment-prod-mvp.md\`** — manual d'onboarding (en Catalan).

## Canvis a fitxers existents

- \`network/anchoring/algorand_reader.py\` — nous helpers \`list_proposal_ids()\` i \`read_proposal_window()\` (decodifica només les dates del head del struct, evitant llegir totes les paperetes a cada poll).
- \`network/anchoring/ethereum_submitter.py\` — nou \`has_submitted()\` per a la idempotència del dimoni.
- \`.gitignore\` — afegit \`.env.prod\`.
- \`network/anchoring/tests/test_algorand_reader.py\` — 4 tests nous cobrint els helpers.

## Verificació

### Tests
- \`pytest network/anchoring/tests/test_algorand_reader.py\`: **22 passed** (18 existents + 4 nous).
- \`pytest\` (voting-contract): **59 passed**.
- \`make lint\`: ✅

### Dimoni contra LocalNet (proxy per a TestNet)

Configurant \`.env.prod\` per apuntar al LocalNet actual (algod localhost, Hardhat localhost, NotaryContract acabat de desplegar):

\`\`\`
[16:13:12] INFO anchoring.daemon: [uib] connected to algod, last_round=1163
[16:13:12] INFO anchoring.daemon: [uib] daemon ready: app_id=2168
                                  notary=0x5FbD...80aa3 submitter=0x7099...79C8 interval=5s
[16:13:12] INFO anchoring.daemon: scan: chain_ts=1779638664 proposals=0
[16:13:17] INFO anchoring.daemon: scan: chain_ts=1779638664 proposals=0
[16:13:22] INFO anchoring.daemon: scan: chain_ts=1779638664 proposals=0
...
\`\`\`

Connexió correcta a algod, lectura de l'estat de la cadena, enumeració de \`pr_*\` boxes (0 propostes en aquest LocalNet net), bucle estable cada 5s.

### Deploy script (dry-run a Hardhat com a proxy de Sepolia)

\`\`\`
[deploy_testnet] network: localhost
[deploy_testnet] admin: 0xf39F...2266 balance: 9999.99 ETH
[deploy_testnet] NotaryContract deployed at: 0xDc64...f6C9
[deploy_testnet] addUniversity(0x7099...79C8) ok
[deploy_testnet] addUniversity(0x3C44...93BC) ok
[deploy_testnet] addUniversity(0x90F7...b906) ok
[deploy_testnet] consensus K-of-N = 2-of-3
\`\`\`

L'únic delta per a Sepolia real és \`--network sepolia\` (ja configurat a \`hardhat.config.js\`), una clau admin finançada amb ETH de testnet i les adreces de les universitats reals.

## Fora d'abast (intencional)

L'MVP no pretén ser producció final. Resta deferit per a iteracions posteriors:

- Gestió de claus amb HSM/KMS (per ara, env vars).
- Multi-sig admin del NotaryContract.
- Integració amb IdP per a la identitat dels votants (E5/E6 del backlog).
- Privacitat del vot (ElGamal + zkSNARK, E3/E4 del backlog).
- Monitorització/alerting més enllà dels logs.

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits
- [x] He executat \`make lint\` i passa sense errors
- [x] Tests del contracte i del dimoni passen al 100 %
- [x] El \`.env.prod\` està al \`.gitignore\` per evitar fuites de claus privades