### PR TITLE
fix(client): elimina l'APP_ID global i empra injecció de dependències

### DIFF
--- a/client/src/algorand/_contract.ts
+++ b/client/src/algorand/_contract.ts
@@ -2,7 +2,7 @@ import type { Address, OrganizationId, ProposalId } from '@/domain'
 
 import algosdk from 'algosdk'
 
-import { algodClient, APP_ID } from './config'
+import { algodClient } from './config'
 import arc56 from './Demochain.arc56.json'
 
 // ── Descodificador d'errors ARC-56 ─────────────────────────────────────────────
@@ -155,6 +155,7 @@ export const castElectionVoteMethod = new algosdk.ABIMethod({
 // ── Executor ATC ─────────────────────────────────────────────────────
 
 export async function callMethod(
+	appId: number,
 	signer: TransactionSigner,
 	sender: string,
 	method: algosdk.ABIMethod,
@@ -165,7 +166,7 @@ export async function callMethod(
 	const composer = new algosdk.AtomicTransactionComposer()
 
 	composer.addMethodCall({
-		appID: APP_ID,
+		appID: appId,
 		method,
 		methodArgs,
 		sender,
@@ -188,9 +189,9 @@ export async function callMethod(
 // Llegeix un comptador uint64 des de l'estat global.
 // Torna a 0 si algod no està disponible (algunes configuracions de nodes no exposen
 // /v2/applications o potser l'aplicació encara no s'ha desplegat).
-export async function readGlobalUint64(keyStr: string): Promise<number> {
+export async function readGlobalUint64(appId: number, keyStr: string): Promise<number> {
 	try {
-		const app = await algodClient.getApplicationByID(APP_ID).do()
+		const app = await algodClient.getApplicationByID(appId).do()
 		const keyBytes = enc.encode(keyStr)
 		const entry = app.params.globalState?.find(key => bytesEqual(key.key, keyBytes))
 		return entry ? Number(entry.value.uint) : 0
@@ -202,9 +203,9 @@ export async function readGlobalUint64(keyStr: string): Promise<number> {
 // ── Comprovacions de l'existència de boxes ─────────────────────────────────────────────
 
 // Lectura directa del box - O(1). L'error 404 es detecta de manera silenciosa.
-export async function singleBoxExists(key: Uint8Array): Promise<boolean> {
+export async function singleBoxExists(appId: number, key: Uint8Array): Promise<boolean> {
 	try {
-		await algodClient.getApplicationBoxByName(APP_ID, key).do()
+		await algodClient.getApplicationBoxByName(appId, key).do()
 		return true
 	} catch {
 		return false
@@ -212,9 +213,9 @@ export async function singleBoxExists(key: Uint8Array): Promise<boolean> {
 }
 
 // Basat en escaneig - evita el 404 en alguns entorns.
-export async function boxExists(key: Uint8Array): Promise<boolean> {
+export async function boxExists(appId: number, key: Uint8Array): Promise<boolean> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		return boxes.some(b => bytesEqual(b.name, key))
 	} catch {
 		return false

--- a/client/src/algorand/config.ts
+++ b/client/src/algorand/config.ts
@@ -4,16 +4,4 @@ const ALGOD_SERVER = import.meta.env['VITE_ALGOD_SERVER'] ?? 'http://localhost'
 const ALGOD_PORT = Number(import.meta.env['VITE_ALGOD_PORT'] ?? 4001)
 const ALGOD_TOKEN = import.meta.env['VITE_ALGOD_TOKEN'] ?? 'a'.repeat(64)
 
-// ── App ID del contracte ─────────────────────────────────────────────────
-// Configurat via VITE_APP_ID (escrit pel servei de contract-deploy de docker compose
-// a client/.env.local a cada 'docker compose up').
-const ENV_APP_ID = import.meta.env['VITE_APP_ID']
-
-export let APP_ID = ENV_APP_ID ? Number(ENV_APP_ID) : 1002
-
-export function setAppIdForTest(id: number): void {
-	APP_ID = id
-}
-
-// ── Client SDK ─────────────────────────────────────────────────────
 export const algodClient = new algosdk.Algodv2(ALGOD_TOKEN, ALGOD_SERVER, ALGOD_PORT)

--- a/client/src/algorand/create-client.ts
+++ b/client/src/algorand/create-client.ts
@@ -1,0 +1,185 @@
+import type { TransactionSigner } from './_contract'
+import type { OnChainOrganization, OnChainProposal, OnChainApprovalTally } from './wire'
+import type { Address, OrganizationId, ProposalId } from '@/domain'
+
+import {
+	createOrganization,
+	addToCensus,
+	removeFromCensus,
+	getOrganization,
+	getAllOrganizationIds,
+	getCensusMembers,
+	getCensusMemberCount,
+	isInCensusChain,
+	type CreateOrganizationResult
+} from './organizations'
+import {
+	createProposal,
+	getProposal,
+	getAllProposalIds,
+	getApprovalTally,
+	type CreateProposalResult
+} from './proposals'
+import {
+	castApprovalVote,
+	castRankedVote,
+	hasApprovalVoted,
+	hasElectionVoted,
+	getElectionVoterCount,
+	getElectionBallots,
+	getElectionBallotForVoter
+} from './voting'
+
+export interface DemochainClient {
+	createOrganization: (
+		signer: TransactionSigner,
+		sender: Address,
+		name: string,
+		description: string
+	) => Promise<CreateOrganizationResult>
+	getOrganization: (orgId: OrganizationId) => Promise<OnChainOrganization | null>
+	getAllOrganizationIds: () => Promise<OrganizationId[]>
+
+	addToCensus: (
+		signer: TransactionSigner,
+		sender: Address,
+		orgId: OrganizationId,
+		members: Address[],
+		onProgress?: (done: number, total: number) => void
+	) => Promise<void>
+	removeFromCensus: (
+		signer: TransactionSigner,
+		sender: Address,
+		orgId: OrganizationId,
+		members: Address[]
+	) => Promise<void>
+	getCensusMembers: (orgId: OrganizationId) => Promise<Address[]>
+	getCensusMemberCount: (orgId: OrganizationId) => Promise<number>
+	isInCensusChain: (address: Address, orgId: OrganizationId) => Promise<boolean>
+
+	createProposal: (
+		signer: TransactionSigner,
+		sender: Address,
+		orgId: OrganizationId,
+		title: string,
+		description: string,
+		options: string[],
+		startingDate: number,
+		endingDate: number
+	) => Promise<CreateProposalResult>
+	getProposal: (proposalId: ProposalId) => Promise<OnChainProposal | null>
+	getAllProposalIds: () => Promise<ProposalId[]>
+
+	getApprovalTally: (proposalId: ProposalId) => Promise<OnChainApprovalTally | null>
+
+	castApprovalVote: (
+		signer: TransactionSigner,
+		sender: Address,
+		proposalId: ProposalId,
+		orgId: OrganizationId,
+		approve: boolean
+	) => Promise<string>
+	castRankedVote: (
+		signer: TransactionSigner,
+		sender: Address,
+		proposalId: ProposalId,
+		orgId: OrganizationId,
+		preferenceOrder: number[]
+	) => Promise<string>
+
+	hasApprovalVoted: (sender: Address, proposalId: ProposalId) => Promise<boolean>
+	hasElectionVoted: (sender: Address, proposalId: ProposalId) => Promise<boolean>
+
+	getElectionVoterCount: (proposalId: ProposalId) => Promise<number>
+	getElectionBallots: (proposalId: ProposalId) => Promise<number[][]>
+	getElectionBallotForVoter: (address: Address, proposalId: ProposalId) => Promise<number[] | null>
+}
+
+export function createDemochainClient(appId: number): DemochainClient {
+	return {
+		// ── Organitzacions ────────────────────────────────────────────────
+		createOrganization: (
+			signer: TransactionSigner,
+			sender: Address,
+			name: string,
+			description: string
+		): Promise<CreateOrganizationResult> => createOrganization(appId, signer, sender, name, description),
+
+		addToCensus: (
+			signer: TransactionSigner,
+			sender: Address,
+			orgId: OrganizationId,
+			members: Address[],
+			onProgress?: (done: number, total: number) => void
+		): Promise<void> => addToCensus(appId, signer, sender, orgId, members, onProgress),
+
+		removeFromCensus: (
+			signer: TransactionSigner,
+			sender: Address,
+			orgId: OrganizationId,
+			members: Address[]
+		): Promise<void> => removeFromCensus(appId, signer, sender, orgId, members),
+
+		getOrganization: (orgId: OrganizationId) => getOrganization(appId, orgId),
+
+		getAllOrganizationIds: () => getAllOrganizationIds(appId),
+
+		getCensusMembers: (orgId: OrganizationId) => getCensusMembers(appId, orgId),
+
+		getCensusMemberCount: (orgId: OrganizationId) => getCensusMemberCount(appId, orgId),
+
+		isInCensusChain: (address: Address, orgId: OrganizationId) => isInCensusChain(appId, address, orgId),
+
+		// ── Propostes ─────────────────────────────────────────────────────
+		createProposal: (
+			signer: TransactionSigner,
+			sender: Address,
+			orgId: OrganizationId,
+			title: string,
+			description: string,
+			options: string[],
+			startingDate: number,
+			endingDate: number
+		): Promise<CreateProposalResult> =>
+			createProposal(appId, signer, sender, orgId, title, description, options, startingDate, endingDate),
+
+		getProposal: (proposalId: ProposalId) => getProposal(appId, proposalId),
+
+		getAllProposalIds: () => getAllProposalIds(appId),
+
+		getApprovalTally: (proposalId: ProposalId) => getApprovalTally(appId, proposalId),
+
+		// ── Votació ───────────────────────────────────────────────────────
+		castApprovalVote: (
+			signer: TransactionSigner,
+			sender: Address,
+			proposalId: ProposalId,
+			orgId: OrganizationId,
+			approve: boolean
+		): Promise<string> => castApprovalVote(appId, signer, sender, proposalId, orgId, approve),
+
+		castRankedVote: (
+			signer: TransactionSigner,
+			sender: Address,
+			proposalId: ProposalId,
+			orgId: OrganizationId,
+			preferenceOrder: number[]
+		): Promise<string> => castRankedVote(appId, signer, sender, proposalId, orgId, preferenceOrder),
+
+		hasApprovalVoted: (sender: Address, proposalId: ProposalId) => hasApprovalVoted(appId, sender, proposalId),
+
+		hasElectionVoted: (sender: Address, proposalId: ProposalId) => hasElectionVoted(appId, sender, proposalId),
+
+		getElectionVoterCount: (proposalId: ProposalId) => getElectionVoterCount(appId, proposalId),
+
+		getElectionBallots: (proposalId: ProposalId) => getElectionBallots(appId, proposalId),
+
+		getElectionBallotForVoter: (address: Address, proposalId: ProposalId) =>
+			getElectionBallotForVoter(appId, address, proposalId)
+	}
+}
+
+// Singleton per a l'app de producció — llegeix VITE_APP_ID una sola vegada en arrancar
+export const demochainClient = createDemochainClient(
+	import.meta.env['VITE_APP_ID'] ? Number(import.meta.env['VITE_APP_ID']) : 1002
+)

--- a/client/src/algorand/governance-client.test.ts
+++ b/client/src/algorand/governance-client.test.ts
@@ -1,3 +1,4 @@
+import type { DemochainClient } from './create-client'
 import type { Address, OrganizationId, ProposalId } from '@/domain'
 
 import { expect, describe, it, beforeAll } from 'bun:test'
@@ -5,29 +6,11 @@ import { expect, describe, it, beforeAll } from 'bun:test'
 import { asAddress, asProposalId, asOrganizationId } from '@/domain'
 import algosdk, { type TransactionSigner } from 'algosdk'
 
-import { algodClient, setAppIdForTest } from './config'
+import { algodClient } from './config'
+import { createDemochainClient } from './create-client'
 import arc56 from './Demochain.arc56.json'
 import { bootstrapDevAccountsToKmd } from './dev-accounts'
 import devAccounts from './dev-accounts.json'
-import {
-	createOrganization,
-	addToCensus,
-	removeFromCensus,
-	getOrganization,
-	getAllOrganizationIds,
-	getCensusMemberCount,
-	getCensusMembers,
-	isInCensusChain
-} from './organizations'
-import { createProposal, getProposal, getAllProposalIds, getApprovalTally } from './proposals'
-import {
-	castApprovalVote,
-	castRankedVote,
-	hasApprovalVoted,
-	hasElectionVoted,
-	getElectionVoterCount,
-	getElectionBallots
-} from './voting'
 
 interface RawDevAddress {
 	address: string
@@ -57,6 +40,7 @@ function signerPer(acct: { mnemonic: string }): TransactionSigner {
 }
 
 // -- Estat compartit mutable (s'estableix durant l'execució ordenada dels tests) -
+let client: DemochainClient = createDemochainClient(0)
 let orgId: OrganizationId = asOrganizationId(0)
 let proposalId: ProposalId = asProposalId(0)
 
@@ -111,6 +95,7 @@ async function deployFreshContract(): Promise<number> {
 		amount: 10_000_000,
 		suggestedParams: sp
 	})
+
 	const signedFund = fundTxn.signTxn(account.sk)
 	const { txid: fundId } = await algodClient.sendRawTransaction(signedFund).do()
 	await algosdk.waitForConfirmation(algodClient, fundId, 4)
@@ -128,7 +113,7 @@ describe("Contracte de Governança - Tests d'integració", () => {
 		await bootstrapDevAccountsToKmd()
 
 		const freshAppId = await deployFreshContract()
-		setAppIdForTest(freshAppId)
+		client = createDemochainClient(freshAppId)
 		console.log(`[test] Contracte nou desplegat - App ID ${freshAppId}`)
 	})
 
@@ -136,7 +121,7 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 	describe("Creació d'organitzacions", () => {
 		it("crea una organització i afegeix l'organitzador al cens", async () => {
-			const { orgId: currentOrgId, txId } = await createOrganization(
+			const { orgId: currentOrgId, txId } = await client.createOrganization(
 				signerPer(organizer),
 				organizer.address,
 				'Ajuntament de Test',
@@ -147,37 +132,42 @@ describe("Contracte de Governança - Tests d'integració", () => {
 			expect(txId).toBeTruthy()
 			orgId = currentOrgId
 
-			const org = await getOrganization(orgId)
+			const org = await client.getOrganization(orgId)
 			expect(org).not.toBeNull()
 			expect(org!.name).toBe('Ajuntament de Test')
 			expect(org!.description).toBe('Organització de prova')
 			expect(org!.organizer).toBe(organizer.address)
 
 			// L'organitzador s'afegeix automàticament al cens
-			expect(await isInCensusChain(organizer.address, orgId)).toBe(true)
-			expect(await getCensusMemberCount(orgId)).toBe(1)
+			expect(await client.isInCensusChain(organizer.address, orgId)).toBe(true)
+			expect(await client.getCensusMemberCount(orgId)).toBe(1)
 		})
 
 		it('apareix a getAllOrganizationIds', async () => {
-			const ids = await getAllOrganizationIds()
+			const ids = await client.getAllOrganizationIds()
 			expect(ids).toContain(orgId)
 		})
 
 		it('rebutja el nom buit → org.empty-name', async () => {
-			expect(createOrganization(signerPer(organizer), organizer.address, '', 'desc')).rejects.toThrow(
+			expect(client.createOrganization(signerPer(organizer), organizer.address, '', 'desc')).rejects.toThrow(
 				/org\.empty-name/
 			)
 		})
 
 		it('rebutja la descripció buida → org.empty-description', async () => {
-			expect(createOrganization(signerPer(organizer), organizer.address, 'Vàlid', '')).rejects.toThrow(
+			expect(client.createOrganization(signerPer(organizer), organizer.address, 'Vàlid', '')).rejects.toThrow(
 				/org\.empty-description/
 			)
 		})
 
 		it('rebutja el nom duplicat → org.already-exists', async () => {
 			expect(
-				createOrganization(signerPer(organizer), organizer.address, 'Ajuntament de Test', 'Altra descripció')
+				client.createOrganization(
+					signerPer(organizer),
+					organizer.address,
+					'Ajuntament de Test',
+					'Altra descripció'
+				)
 			).rejects.toThrow(/org\.already-exists/)
 		})
 	})
@@ -186,15 +176,15 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 	describe('Gestió del cens', () => {
 		it("l'organitzador afegeix membres al cens", async () => {
-			await addToCensus(signerPer(organizer), organizer.address, orgId, [member1.address, member2.address])
+			await client.addToCensus(signerPer(organizer), organizer.address, orgId, [member1.address, member2.address])
 
-			expect(await isInCensusChain(member1.address, orgId)).toBe(true)
-			expect(await isInCensusChain(member2.address, orgId)).toBe(true)
-			expect(await getCensusMemberCount(orgId)).toBe(3)
+			expect(await client.isInCensusChain(member1.address, orgId)).toBe(true)
+			expect(await client.isInCensusChain(member2.address, orgId)).toBe(true)
+			expect(await client.getCensusMemberCount(orgId)).toBe(3)
 		})
 
 		it('getCensusMembers retorna tots els membres', async () => {
-			const membres = await getCensusMembers(orgId)
+			const membres = await client.getCensusMembers(orgId)
 			expect(membres).toContain(organizer.address)
 			expect(membres).toContain(member1.address)
 			expect(membres).toContain(member2.address)
@@ -202,42 +192,42 @@ describe("Contracte de Governança - Tests d'integració", () => {
 		})
 
 		it("rebutja afegir al cens si no és l'organitzador → org.unauthorized", async () => {
-			expect(addToCensus(signerPer(member1), member1.address, orgId, [outsider.address])).rejects.toThrow(
+			expect(client.addToCensus(signerPer(member1), member1.address, orgId, [outsider.address])).rejects.toThrow(
 				/org\.unauthorized/
 			)
 		})
 
 		it('rebutja afegir un membre duplicat → org.census.duplicated-address', async () => {
-			expect(addToCensus(signerPer(organizer), organizer.address, orgId, [member1.address])).rejects.toThrow(
-				/org\.census\.duplicated-address/
-			)
+			expect(
+				client.addToCensus(signerPer(organizer), organizer.address, orgId, [member1.address])
+			).rejects.toThrow(/org\.census\.duplicated-address/)
 		})
 
 		it("l'organitzador elimina un membre del cens", async () => {
-			await removeFromCensus(signerPer(organizer), organizer.address, orgId, [member2.address])
-			expect(await isInCensusChain(member2.address, orgId)).toBe(false)
-			expect(await getCensusMemberCount(orgId)).toBe(2)
+			await client.removeFromCensus(signerPer(organizer), organizer.address, orgId, [member2.address])
+			expect(await client.isInCensusChain(member2.address, orgId)).toBe(false)
+			expect(await client.getCensusMemberCount(orgId)).toBe(2)
 		})
 
 		it("rebutja eliminar del cens si no és l'organitzador → org.unauthorized", async () => {
-			expect(removeFromCensus(signerPer(member1), member1.address, orgId, [organizer.address])).rejects.toThrow(
-				/org\.unauthorized/
-			)
+			expect(
+				client.removeFromCensus(signerPer(member1), member1.address, orgId, [organizer.address])
+			).rejects.toThrow(/org\.unauthorized/)
 		})
 
 		it('rebutja eliminar una adreça no registrada → org.census.non-registered-address', async () => {
 			expect(
-				removeFromCensus(signerPer(organizer), organizer.address, orgId, [outsider.address])
+				client.removeFromCensus(signerPer(organizer), organizer.address, orgId, [outsider.address])
 			).rejects.toThrow(/org\.census\.non-registered-address/)
 		})
 
 		it('un extern no és al cens', async () => {
-			expect(await isInCensusChain(outsider.address, orgId)).toBe(false)
+			expect(await client.isInCensusChain(outsider.address, orgId)).toBe(false)
 		})
 
 		it('torna a afegir member2 per als tests posteriors', async () => {
-			await addToCensus(signerPer(organizer), organizer.address, orgId, [member2.address])
-			expect(await getCensusMemberCount(orgId)).toBe(3)
+			await client.addToCensus(signerPer(organizer), organizer.address, orgId, [member2.address])
+			expect(await client.getCensusMemberCount(orgId)).toBe(3)
 		})
 	})
 
@@ -248,7 +238,7 @@ describe("Contracte de Governança - Tests d'integració", () => {
 		const final = () => inici() + 86400
 
 		it('un membre del cens crea una proposta', async () => {
-			const { proposalId: currentProposalId, txId } = await createProposal(
+			const { proposalId: currentProposalId, txId } = await client.createProposal(
 				signerPer(member1),
 				member1.address,
 				orgId,
@@ -263,7 +253,7 @@ describe("Contracte de Governança - Tests d'integració", () => {
 			expect(txId).toBeTruthy()
 			proposalId = currentProposalId
 
-			const prop = await getProposal(proposalId)
+			const prop = await client.getProposal(proposalId)
 			expect(prop).not.toBeNull()
 			expect(prop!.title).toBe('Construir parc')
 			expect(prop!.options).toEqual(['Opció A', 'Opció B', 'Opció C'])
@@ -271,12 +261,12 @@ describe("Contracte de Governança - Tests d'integració", () => {
 		})
 
 		it('apareix a getAllProposalIds', async () => {
-			const ids = await getAllProposalIds()
+			const ids = await client.getAllProposalIds()
 			expect(ids).toContain(proposalId)
 		})
 
 		it('el recompte comença a zero', async () => {
-			const tally = await getApprovalTally(proposalId)
+			const tally = await client.getApprovalTally(proposalId)
 			expect(tally).not.toBeNull()
 			expect(tally!.votesFor).toBe(0)
 			expect(tally!.totalVotes).toBe(0)
@@ -284,7 +274,7 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 		it('rebutja un membre fora del cens → org.census.unauthorized', async () => {
 			expect(
-				createProposal(
+				client.createProposal(
 					signerPer(outsider),
 					outsider.address,
 					orgId,
@@ -299,19 +289,37 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 		it('rebutja el títol buit → proposal.empty-title', async () => {
 			expect(
-				createProposal(signerPer(member1), member1.address, orgId, '', 'Desc', ['A', 'B'], inici(), final())
+				client.createProposal(
+					signerPer(member1),
+					member1.address,
+					orgId,
+					'',
+					'Desc',
+					['A', 'B'],
+					inici(),
+					final()
+				)
 			).rejects.toThrow(/proposal\.empty-title/)
 		})
 
 		it('rebutja la descripció buida → proposal.empty-description', async () => {
 			expect(
-				createProposal(signerPer(member1), member1.address, orgId, 'Títol', '', ['A', 'B'], inici(), final())
+				client.createProposal(
+					signerPer(member1),
+					member1.address,
+					orgId,
+					'Títol',
+					'',
+					['A', 'B'],
+					inici(),
+					final()
+				)
 			).rejects.toThrow(/proposal\.empty-description/)
 		})
 
 		it('rebutja menys de 2 opcions → proposal.too-few-options', async () => {
 			expect(
-				createProposal(
+				client.createProposal(
 					signerPer(member1),
 					member1.address,
 					orgId,
@@ -326,13 +334,22 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 		it('rebutja una opció buida → proposal.empty-option', async () => {
 			expect(
-				createProposal(signerPer(member1), member1.address, orgId, 'Títol', 'Desc', ['A', ''], inici(), final())
+				client.createProposal(
+					signerPer(member1),
+					member1.address,
+					orgId,
+					'Títol',
+					'Desc',
+					['A', ''],
+					inici(),
+					final()
+				)
 			).rejects.toThrow(/proposal\.empty-option/)
 		})
 
 		it('rebutja opcions duplicades → proposal.duplicated-option', async () => {
 			expect(
-				createProposal(
+				client.createProposal(
 					signerPer(member1),
 					member1.address,
 					orgId,
@@ -350,48 +367,48 @@ describe("Contracte de Governança - Tests d'integració", () => {
 
 	describe("Votació d'aprovació", () => {
 		it('member1 aprova la proposta', async () => {
-			const txId = await castApprovalVote(signerPer(member1), member1.address, proposalId, orgId, true)
+			const txId = await client.castApprovalVote(signerPer(member1), member1.address, proposalId, orgId, true)
 			expect(txId).toBeTruthy()
 
-			expect(await hasApprovalVoted(member1.address, proposalId)).toBe(true)
+			expect(await client.hasApprovalVoted(member1.address, proposalId)).toBe(true)
 
-			const tally = await getApprovalTally(proposalId)
+			const tally = await client.getApprovalTally(proposalId)
 			expect(tally!.votesFor).toBe(1)
 			expect(tally!.totalVotes).toBe(1)
 		})
 
 		it("member2 rebutja la proposta (approve=false) - el recompte s'actualitza correctament", async () => {
-			await castApprovalVote(signerPer(member2), member2.address, proposalId, orgId, false)
+			await client.castApprovalVote(signerPer(member2), member2.address, proposalId, orgId, false)
 
-			const tally = await getApprovalTally(proposalId)
+			const tally = await client.getApprovalTally(proposalId)
 			expect(tally!.votesFor).toBe(1) // sense canvis - rebuig
 			expect(tally!.totalVotes).toBe(2) // incrementat
 		})
 
 		it("l'organitzador aprova - s'assoleix el llindar 2/3", async () => {
-			await castApprovalVote(signerPer(organizer), organizer.address, proposalId, orgId, true)
+			await client.castApprovalVote(signerPer(organizer), organizer.address, proposalId, orgId, true)
 
-			const tally = await getApprovalTally(proposalId)
+			const tally = await client.getApprovalTally(proposalId)
 			expect(tally!.votesFor).toBe(2)
 			expect(tally!.totalVotes).toBe(3)
 			// 3 * 2 = 6 >= 2 * 3 = 6 → aprovada ✓
 		})
 
 		it('rebutja un vot duplicat → proposal.already-voted', async () => {
-			expect(castApprovalVote(signerPer(member1), member1.address, proposalId, orgId, true)).rejects.toThrow(
-				/proposal\.already-voted/
-			)
+			expect(
+				client.castApprovalVote(signerPer(member1), member1.address, proposalId, orgId, true)
+			).rejects.toThrow(/proposal\.already-voted/)
 		})
 
 		it('rebutja un membre fora del cens → org.census.unauthorized', async () => {
-			expect(castApprovalVote(signerPer(outsider), outsider.address, proposalId, orgId, true)).rejects.toThrow(
-				/org\.census\.unauthorized/
-			)
+			expect(
+				client.castApprovalVote(signerPer(outsider), outsider.address, proposalId, orgId, true)
+			).rejects.toThrow(/org\.census\.unauthorized/)
 		})
 
 		it('rebutja votar una proposta inexistent → proposal.not-found', async () => {
 			expect(
-				castApprovalVote(signerPer(member1), member1.address, asProposalId(99999), orgId, true)
+				client.castApprovalVote(signerPer(member1), member1.address, asProposalId(99999), orgId, true)
 			).rejects.toThrow(/proposal\.not-found/)
 		})
 	})
@@ -399,10 +416,17 @@ describe("Contracte de Governança - Tests d'integració", () => {
 	// --- Votació d'elecció (preferencial) -----------------------------
 
 	describe("Votació d'elecció (preferencial)", () => {
+		beforeAll(async () => {
+			// startingDate = now en el moment de crear la proposta.
+			// Global.latest_timestamp d'Algorand va endarrerit ~3-4 s respecte el
+			// rellotge real. Esperem un bloc complet per garantir que startingDate
+			// ja ha passat abans d'enviar vots d'elecció.
+			await new Promise(resolve => setTimeout(resolve, 4500))
+		})
 		it("rebutja el vot d'elecció en una proposta no aprovada → proposal.not-accepted", async () => {
 			// Crea una segona proposta que ningú aprova
 			const start = Math.floor(Date.now() / 1000)
-			const { proposalId: pid2 } = await createProposal(
+			const { proposalId: pid2 } = await client.createProposal(
 				signerPer(member1),
 				member1.address,
 				orgId,
@@ -413,35 +437,41 @@ describe("Contracte de Governança - Tests d'integració", () => {
 				start + 86400
 			)
 
-			expect(castRankedVote(signerPer(member1), member1.address, pid2, orgId, [1, 0])).rejects.toThrow(
+			expect(client.castRankedVote(signerPer(member1), member1.address, pid2, orgId, [1, 0])).rejects.toThrow(
 				/proposal\.not-accepted/
 			)
 		})
 
 		it('emet un vot preferencial en una proposta aprovada', async () => {
 			// 'proposalId' ha assolit el 2/3 d'aprovació al bloc anterior
-			const txId = await castRankedVote(signerPer(organizer), organizer.address, proposalId, orgId, [2, 0, 1])
+			const txId = await client.castRankedVote(
+				signerPer(organizer),
+				organizer.address,
+				proposalId,
+				orgId,
+				[2, 0, 1]
+			)
 			expect(txId).toBeTruthy()
 
-			expect(await hasElectionVoted(organizer.address, proposalId)).toBe(true)
-			expect(await getElectionVoterCount(proposalId)).toBe(1)
+			expect(await client.hasElectionVoted(organizer.address, proposalId)).toBe(true)
+			expect(await client.getElectionVoterCount(proposalId)).toBe(1)
 		})
 
 		it('llegeix les paperetes correctament', async () => {
-			const paperetes = await getElectionBallots(proposalId)
+			const paperetes = await client.getElectionBallots(proposalId)
 			expect(paperetes.length).toBe(1)
 			expect(paperetes[0]).toEqual([2, 0, 1])
 		})
 
 		it("rebutja un vot d'elecció duplicat → election.already-voted", async () => {
 			expect(
-				castRankedVote(signerPer(organizer), organizer.address, proposalId, orgId, [0, 1, 2])
+				client.castRankedVote(signerPer(organizer), organizer.address, proposalId, orgId, [0, 1, 2])
 			).rejects.toThrow(/election\.already-voted/)
 		})
 
 		it('rebutja un ordre de preferències invàlid → election.missing-options', async () => {
 			expect(
-				castRankedVote(
+				client.castRankedVote(
 					signerPer(member1),
 					member1.address,
 					proposalId,
@@ -452,16 +482,16 @@ describe("Contracte de Governança - Tests d'integració", () => {
 		})
 
 		it('rebutja un membre fora del cens → org.census.unauthorized', async () => {
-			expect(castRankedVote(signerPer(outsider), outsider.address, proposalId, orgId, [0, 1, 2])).rejects.toThrow(
-				/org\.census\.unauthorized/
-			)
+			expect(
+				client.castRankedVote(signerPer(outsider), outsider.address, proposalId, orgId, [0, 1, 2])
+			).rejects.toThrow(/org\.census\.unauthorized/)
 		})
 
 		it('member1 també vota - múltiples paperetes', async () => {
-			await castRankedVote(signerPer(member1), member1.address, proposalId, orgId, [1, 2, 0])
+			await client.castRankedVote(signerPer(member1), member1.address, proposalId, orgId, [1, 2, 0])
 
-			expect(await getElectionVoterCount(proposalId)).toBe(2)
-			const paperetes = await getElectionBallots(proposalId)
+			expect(await client.getElectionVoterCount(proposalId)).toBe(2)
+			const paperetes = await client.getElectionBallots(proposalId)
 			expect(paperetes.length).toBe(2)
 		})
 	})

--- a/client/src/algorand/mutations.ts
+++ b/client/src/algorand/mutations.ts
@@ -1,13 +1,12 @@
 import type { CreateOrganizationResult } from './organizations'
+import type { CreateProposalResult } from './proposals'
 import type { Address, OrganizationId, ProposalId } from '@/domain'
 import type algosdk from 'algosdk'
 
 import { useMutation, type UseMutationResult, useQueryClient } from '@tanstack/react-query'
 
-import { createOrganization, addToCensus, removeFromCensus } from './organizations'
-import { createProposal, type CreateProposalResult } from './proposals'
+import { demochainClient } from './create-client'
 import { queryKeys } from './query-keys'
-import { castApprovalVote, castRankedVote } from './voting'
 
 // ── Shared argument shapes ───────────────────────────────────────────
 
@@ -55,7 +54,7 @@ export function useCreateOrganization(): UseMutationResult<CreateOrganizationRes
 
 	return useMutation({
 		mutationFn: ({ signer, sender, name, description }: CreateOrganizationArgs) =>
-			createOrganization(signer, sender, name, description),
+			demochainClient.createOrganization(signer, sender, name, description),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all() })
 		}
@@ -67,7 +66,7 @@ export function useAddToCensus(): UseMutationResult<void, Error, CensusArgs> {
 
 	return useMutation({
 		mutationFn: ({ signer, sender, orgId, members, onProgress }: CensusArgs) =>
-			addToCensus(signer, sender, orgId, members, onProgress),
+			demochainClient.addToCensus(signer, sender, orgId, members, onProgress),
 		onSuccess: (_data, { orgId }) => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.organizations.detail(orgId) })
 			void queryClient.invalidateQueries({ queryKey: queryKeys.censusPrefix })
@@ -80,7 +79,7 @@ export function useRemoveFromCensus(): UseMutationResult<void, Error, CensusArgs
 
 	return useMutation({
 		mutationFn: ({ signer, sender, orgId, members }: CensusArgs) =>
-			removeFromCensus(signer, sender, orgId, members),
+			demochainClient.removeFromCensus(signer, sender, orgId, members),
 		onSuccess: (_data, { orgId }) => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.organizations.detail(orgId) })
 			void queryClient.invalidateQueries({ queryKey: queryKeys.censusPrefix })
@@ -102,7 +101,16 @@ export function useCreateProposal(): UseMutationResult<CreateProposalResult, Err
 			startingDate,
 			endingDate
 		}: CreateProposalArgs) =>
-			createProposal(signer, sender, orgId, title, description, options, startingDate, endingDate),
+			demochainClient.createProposal(
+				signer,
+				sender,
+				orgId,
+				title,
+				description,
+				options,
+				startingDate,
+				endingDate
+			),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() })
 		}
@@ -114,7 +122,7 @@ export function useCastApprovalVote(): UseMutationResult<string, Error, CastAppr
 
 	return useMutation({
 		mutationFn: ({ signer, sender, proposalId, orgId, approve }: CastApprovalVoteArgs) =>
-			castApprovalVote(signer, sender, proposalId, orgId, approve),
+			demochainClient.castApprovalVote(signer, sender, proposalId, orgId, approve),
 		onSuccess: (_txId, { proposalId, sender }) => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.detail(proposalId) })
 			void queryClient.invalidateQueries({ queryKey: queryKeys.proposals.all() })
@@ -128,7 +136,7 @@ export function useCastRankedVote(): UseMutationResult<string, Error, CastRanked
 
 	return useMutation({
 		mutationFn: ({ signer, sender, proposalId, orgId, preferenceOrder }: CastRankedVoteArgs) =>
-			castRankedVote(signer, sender, proposalId, orgId, preferenceOrder),
+			demochainClient.castRankedVote(signer, sender, proposalId, orgId, preferenceOrder),
 		onSuccess: (_txId, { proposalId, sender }) => {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.voting.electionVoted(sender, proposalId) })
 			void queryClient.invalidateQueries({ queryKey: queryKeys.electionPrefix })

--- a/client/src/algorand/organizations.ts
+++ b/client/src/algorand/organizations.ts
@@ -20,7 +20,7 @@ import {
 	removeFromCensusMethod,
 	createOrganizationMethod
 } from './_contract'
-import { algodClient, APP_ID } from './config'
+import { algodClient } from './config'
 
 export interface CreateOrganizationResult {
 	orgId: OrganizationId
@@ -28,16 +28,17 @@ export interface CreateOrganizationResult {
 }
 
 export async function createOrganization(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	name: string,
 	description: string
 ): Promise<CreateOrganizationResult> {
-	const currentOrgId = asOrganizationId(await readGlobalUint64('org_id'))
+	const currentOrgId = asOrganizationId(await readGlobalUint64(appId, 'org_id'))
 	const nextId = asOrganizationId(currentOrgId + 1)
 
 	const suggestedParams = await algodClient.getTransactionParams().do()
-	const appAddress = algosdk.getApplicationAddress(APP_ID)
+	const appAddress = algosdk.getApplicationAddress(appId)
 
 	// Paga el compte de l'aplicació per cobrir MBR per a les 3 boxes que crearà:
 	// box org (key=12, value=8+2+nom+2+desc+32), box d'índex de nom, box de cens organitzador
@@ -59,16 +60,16 @@ export async function createOrganization(
 
 	composer.addTransaction({ txn: payTxn, signer })
 	composer.addMethodCall({
-		appID: APP_ID,
+		appID: appId,
 		method: createOrganizationMethod,
 		methodArgs: [name, description],
 		sender,
 		signer,
 		suggestedParams,
 		boxes: [
-			{ appIndex: APP_ID, name: orgNameIndexKey(name) },
-			{ appIndex: APP_ID, name: orgBoxKey(nextId) },
-			{ appIndex: APP_ID, name: censusBoxKey(nextId, sender) }
+			{ appIndex: appId, name: orgNameIndexKey(name) },
+			{ appIndex: appId, name: orgBoxKey(nextId) },
+			{ appIndex: appId, name: censusBoxKey(nextId, sender) }
 		]
 	})
 
@@ -88,18 +89,18 @@ export async function createOrganization(
 	throw new Error('No contract result')
 }
 
-export async function getOrganization(orgId: OrganizationId): Promise<OnChainOrganization | null> {
+export async function getOrganization(appId: number, orgId: OrganizationId): Promise<OnChainOrganization | null> {
 	try {
-		const box = await algodClient.getApplicationBoxByName(APP_ID, orgBoxKey(orgId)).do()
+		const box = await algodClient.getApplicationBoxByName(appId, orgBoxKey(orgId)).do()
 		return decodeOrganization(box.value)
 	} catch {
 		return null
 	}
 }
 
-export async function getAllOrganizationIds(): Promise<OrganizationId[]> {
+export async function getAllOrganizationIds(appId: number): Promise<OrganizationId[]> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const orgPrefix = enc.encode('org_') // 4 bytes
 		const ids: OrganizationId[] = []
 
@@ -117,6 +118,7 @@ export async function getAllOrganizationIds(): Promise<OrganizationId[]> {
 }
 
 export async function addToCensus(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	orgId: OrganizationId,
@@ -125,8 +127,7 @@ export async function addToCensus(
 ): Promise<void> {
 	if (members.length === 0) return
 
-	const appAddress = algosdk.getApplicationAddress(APP_ID)
-
+	const appAddress = algosdk.getApplicationAddress(appId)
 	const batches: Address[][] = []
 
 	for (let i = 0; i < members.length; i += CENSUS_BATCH) batches.push(members.slice(i, i + CENSUS_BATCH))
@@ -148,15 +149,15 @@ export async function addToCensus(
 				const composer = new algosdk.AtomicTransactionComposer()
 				composer.addTransaction({ txn: payTxn, signer })
 				composer.addMethodCall({
-					appID: APP_ID,
+					appID: appId,
 					method: addToCensusMethod,
 					methodArgs: [BigInt(orgId), batch],
 					sender,
 					signer,
 					suggestedParams,
 					boxes: [
-						{ appIndex: APP_ID, name: orgBoxKey(orgId) },
-						...batch.map(address => ({ appIndex: APP_ID, name: censusBoxKey(orgId, address) }))
+						{ appIndex: appId, name: orgBoxKey(orgId) },
+						...batch.map(address => ({ appIndex: appId, name: censusBoxKey(orgId, address) }))
 					]
 				})
 
@@ -171,6 +172,7 @@ export async function addToCensus(
 }
 
 export async function removeFromCensus(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	orgId: OrganizationId,
@@ -185,15 +187,15 @@ export async function removeFromCensus(
 		const batch = members.slice(i, i + CENSUS_BATCH)
 
 		composer.addMethodCall({
-			appID: APP_ID,
+			appID: appId,
 			method: removeFromCensusMethod,
 			methodArgs: [BigInt(orgId), batch],
 			sender,
 			signer,
 			suggestedParams,
 			boxes: [
-				{ appIndex: APP_ID, name: orgBoxKey(orgId) },
-				...batch.map(address => ({ appIndex: APP_ID, name: censusBoxKey(orgId, address) }))
+				{ appIndex: appId, name: orgBoxKey(orgId) },
+				...batch.map(address => ({ appIndex: appId, name: censusBoxKey(orgId, address) }))
 			]
 		})
 	}
@@ -205,9 +207,9 @@ export async function removeFromCensus(
 	}
 }
 
-export async function getCensusMembers(orgId: OrganizationId): Promise<Address[]> {
+export async function getCensusMembers(appId: number, orgId: OrganizationId): Promise<Address[]> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const prefix = enc.encode('cs_') // 3 bytes
 		const orgIdBytes = algosdk.bigIntToBytes(orgId, 8)
 		const members: Address[] = []
@@ -223,9 +225,9 @@ export async function getCensusMembers(orgId: OrganizationId): Promise<Address[]
 	}
 }
 
-export async function getCensusMemberCount(orgId: OrganizationId): Promise<number> {
+export async function getCensusMemberCount(appId: number, orgId: OrganizationId): Promise<number> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const prefix = enc.encode('cs_')
 		const orgIdBytes = algosdk.bigIntToBytes(orgId, 8)
 
@@ -240,8 +242,8 @@ export async function getCensusMemberCount(orgId: OrganizationId): Promise<numbe
 	}
 }
 
-export async function isInCensusChain(address: Address, orgId: OrganizationId): Promise<boolean> {
-	return singleBoxExists(censusBoxKey(orgId, address))
+export async function isInCensusChain(appId: number, address: Address, orgId: OrganizationId): Promise<boolean> {
+	return singleBoxExists(appId, censusBoxKey(orgId, address))
 }
 
 function decodeOrganization(data: Uint8Array): OnChainOrganization {

--- a/client/src/algorand/proposals.ts
+++ b/client/src/algorand/proposals.ts
@@ -16,7 +16,7 @@ import {
 	enc,
 	createProposalMethod
 } from './_contract'
-import { algodClient, APP_ID } from './config'
+import { algodClient } from './config'
 
 export interface CreateProposalResult {
 	proposalId: ProposalId
@@ -24,6 +24,7 @@ export interface CreateProposalResult {
 }
 
 export async function createProposal(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	orgId: OrganizationId,
@@ -36,20 +37,21 @@ export async function createProposal(
 	const lower = options.map(option => option.toLowerCase())
 	if (new Set(lower).size !== lower.length) throw new Error('proposal.duplicated-option')
 
-	const currentProposalId = asProposalId(await readGlobalUint64('proposal_id'))
+	const currentProposalId = asProposalId(await readGlobalUint64(appId, 'proposal_id'))
 	const nextId = asProposalId(currentProposalId + 1)
 
 	// create_proposal calls _assert_in_census, so census box is required too.
 	const result = await callMethod(
+		appId,
 		signer,
 		sender,
 		createProposalMethod,
 		[BigInt(orgId), title, description, options, BigInt(startingDate), BigInt(endingDate)],
 		[
-			{ appIndex: APP_ID, name: proposalBoxKey(nextId) },
-			{ appIndex: APP_ID, name: tallyBoxKey(nextId) },
-			{ appIndex: APP_ID, name: orgBoxKey(orgId) },
-			{ appIndex: APP_ID, name: censusBoxKey(orgId, sender) }
+			{ appIndex: appId, name: proposalBoxKey(nextId) },
+			{ appIndex: appId, name: tallyBoxKey(nextId) },
+			{ appIndex: appId, name: orgBoxKey(orgId) },
+			{ appIndex: appId, name: censusBoxKey(orgId, sender) }
 		]
 	)
 
@@ -60,27 +62,27 @@ export async function createProposal(
 	}
 }
 
-export async function getProposal(proposalId: ProposalId): Promise<OnChainProposal | null> {
+export async function getProposal(appId: number, proposalId: ProposalId): Promise<OnChainProposal | null> {
 	try {
-		const box = await algodClient.getApplicationBoxByName(APP_ID, proposalBoxKey(proposalId)).do()
+		const box = await algodClient.getApplicationBoxByName(appId, proposalBoxKey(proposalId)).do()
 		return decodeProposal(box.value)
 	} catch {
 		return null
 	}
 }
 
-export async function getApprovalTally(proposalId: ProposalId): Promise<OnChainApprovalTally | null> {
+export async function getApprovalTally(appId: number, proposalId: ProposalId): Promise<OnChainApprovalTally | null> {
 	try {
-		const box = await algodClient.getApplicationBoxByName(APP_ID, tallyBoxKey(proposalId)).do()
+		const box = await algodClient.getApplicationBoxByName(appId, tallyBoxKey(proposalId)).do()
 		return decodeTally(box.value)
 	} catch {
 		return null
 	}
 }
 
-export async function getAllProposalIds(): Promise<ProposalId[]> {
+export async function getAllProposalIds(appId: number): Promise<ProposalId[]> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const proposalPrefix = enc.encode('pr_') // 3 bytes
 		const ids: ProposalId[] = []
 

--- a/client/src/algorand/queries.ts
+++ b/client/src/algorand/queries.ts
@@ -6,53 +6,39 @@ import { queryOptions } from '@tanstack/react-query'
 
 type Opts<TData, Key extends QueryKey> = UndefinedInitialDataOptions<TData, Error, TData, Key>
 
+import { demochainClient } from './create-client'
 import { mapToOrganization, mapToProposal } from './mappers'
-import {
-	getOrganization,
-	getAllOrganizationIds,
-	getCensusMembers,
-	getCensusMemberCount,
-	isInCensusChain
-} from './organizations'
-import { getAllProposalIds, getApprovalTally, getProposal } from './proposals'
 import { queryKeys } from './query-keys'
-import {
-	hasApprovalVoted,
-	hasElectionVoted,
-	getElectionVoterCount,
-	getElectionBallots,
-	getElectionBallotForVoter
-} from './voting'
 
 // ── Fetchers asíncrons ────────────────────────────────────────────────────
 
 async function fetchOrganization(id: OrganizationId): Promise<Organization | null> {
-	const onChain = await getOrganization(id)
+	const onChain = await demochainClient.getOrganization(id)
 	if (!onChain) return null
-	const memberCount = await getCensusMemberCount(id)
+	const memberCount = await demochainClient.getCensusMemberCount(id)
 	return mapToOrganization(id, onChain, memberCount)
 }
 
 async function fetchOrganizations(): Promise<Organization[]> {
-	const ids = await getAllOrganizationIds()
+	const ids = await demochainClient.getAllOrganizationIds()
 	const results = await Promise.all(ids.map(fetchOrganization))
 	return results.filter((org): org is Organization => org !== null)
 }
 
 async function fetchCensusMembers(orgId: OrganizationId): Promise<Address[]> {
-	return getCensusMembers(orgId)
+	return demochainClient.getCensusMembers(orgId)
 }
 
 async function fetchIsInCensus(address: Address, orgId: OrganizationId): Promise<boolean> {
-	return isInCensusChain(address, orgId)
+	return demochainClient.isInCensusChain(address, orgId)
 }
 
 async function fetchUserOrganizations(address: Address): Promise<Organization[]> {
-	const ids = await getAllOrganizationIds()
+	const ids = await demochainClient.getAllOrganizationIds()
 
 	const results = await Promise.all(
 		ids.map(async id => {
-			const isMember = await isInCensusChain(address, id)
+			const isMember = await demochainClient.isInCensusChain(address, id)
 			if (!isMember) return null
 			return fetchOrganization(id)
 		})
@@ -62,35 +48,35 @@ async function fetchUserOrganizations(address: Address): Promise<Organization[]>
 }
 
 async function fetchProposal(id: ProposalId): Promise<Proposal | null> {
-	const onChain = await getProposal(id)
+	const onChain = await demochainClient.getProposal(id)
 	if (!onChain) return null
-	const tally = await getApprovalTally(id)
+	const tally = await demochainClient.getApprovalTally(id)
 	if (!tally) return null
-	const memberCount = await getCensusMemberCount(onChain.orgId)
+	const memberCount = await demochainClient.getCensusMemberCount(onChain.orgId)
 	return mapToProposal(id, onChain, tally, memberCount)
 }
 
 async function fetchProposals(): Promise<Proposal[]> {
-	const ids = await getAllProposalIds()
+	const ids = await demochainClient.getAllProposalIds()
 	const results = await Promise.all(ids.map(fetchProposal))
 
 	return results.filter((proposal): proposal is Proposal => proposal !== null)
 }
 
 async function fetchHasApprovalVoted(address: Address, proposalId: ProposalId): Promise<boolean> {
-	return hasApprovalVoted(address, proposalId)
+	return demochainClient.hasApprovalVoted(address, proposalId)
 }
 
 async function fetchHasElectionVoted(address: Address, proposalId: ProposalId): Promise<boolean> {
-	return hasElectionVoted(address, proposalId)
+	return demochainClient.hasElectionVoted(address, proposalId)
 }
 
 async function fetchElectionVoterCount(proposalId: ProposalId): Promise<number> {
-	return getElectionVoterCount(proposalId)
+	return demochainClient.getElectionVoterCount(proposalId)
 }
 
 async function fetchElectionResults(proposalId: ProposalId, numOptions: number): Promise<ElectionResults> {
-	const ballots = await getElectionBallots(proposalId)
+	const ballots = await demochainClient.getElectionBallots(proposalId)
 	return computeElectionResults(asProposalId(proposalId), ballots, numOptions)
 }
 
@@ -178,7 +164,7 @@ export const votingQueries = {
 	): Opts<number[] | null, ReturnType<typeof queryKeys.voting.electionBallotForVoter>> =>
 		queryOptions({
 			queryKey: queryKeys.voting.electionBallotForVoter(address, proposalId),
-			queryFn: () => getElectionBallotForVoter(address, proposalId),
+			queryFn: () => demochainClient.getElectionBallotForVoter(address, proposalId),
 			enabled: Boolean(address),
 			retry: false,
 			staleTime: 30_000

--- a/client/src/algorand/voting.ts
+++ b/client/src/algorand/voting.ts
@@ -17,9 +17,10 @@ import {
 	castProposalVoteMethod,
 	castElectionVoteMethod
 } from './_contract'
-import { algodClient, APP_ID } from './config'
+import { algodClient } from './config'
 
 export async function castApprovalVote(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	proposalId: ProposalId,
@@ -27,16 +28,17 @@ export async function castApprovalVote(
 	approve: boolean
 ): Promise<string> {
 	const result = await callMethod(
+		appId,
 		signer,
 		sender,
 		castProposalVoteMethod,
 		[BigInt(proposalId), approve],
 		[
-			{ appIndex: APP_ID, name: proposalBoxKey(proposalId) },
-			{ appIndex: APP_ID, name: tallyBoxKey(proposalId) },
-			{ appIndex: APP_ID, name: approvalBallotKey(sender, proposalId) },
-			{ appIndex: APP_ID, name: orgBoxKey(orgId) },
-			{ appIndex: APP_ID, name: censusBoxKey(orgId, sender) }
+			{ appIndex: appId, name: proposalBoxKey(proposalId) },
+			{ appIndex: appId, name: tallyBoxKey(proposalId) },
+			{ appIndex: appId, name: approvalBallotKey(sender, proposalId) },
+			{ appIndex: appId, name: orgBoxKey(orgId) },
+			{ appIndex: appId, name: censusBoxKey(orgId, sender) }
 		]
 	)
 
@@ -44,6 +46,7 @@ export async function castApprovalVote(
 }
 
 export async function castRankedVote(
+	appId: number,
 	signer: TransactionSigner,
 	sender: Address,
 	proposalId: ProposalId,
@@ -51,25 +54,26 @@ export async function castRankedVote(
 	preferenceOrder: number[]
 ): Promise<string> {
 	const result = await callMethod(
+		appId,
 		signer,
 		sender,
 		castElectionVoteMethod,
 		[BigInt(proposalId), preferenceOrder.map(optionOrder => BigInt(optionOrder))],
 		[
-			{ appIndex: APP_ID, name: proposalBoxKey(proposalId) },
-			{ appIndex: APP_ID, name: tallyBoxKey(proposalId) },
-			{ appIndex: APP_ID, name: electionBallotKey(sender, proposalId) },
-			{ appIndex: APP_ID, name: orgBoxKey(orgId) },
-			{ appIndex: APP_ID, name: censusBoxKey(orgId, sender) }
+			{ appIndex: appId, name: proposalBoxKey(proposalId) },
+			{ appIndex: appId, name: tallyBoxKey(proposalId) },
+			{ appIndex: appId, name: electionBallotKey(sender, proposalId) },
+			{ appIndex: appId, name: orgBoxKey(orgId) },
+			{ appIndex: appId, name: censusBoxKey(orgId, sender) }
 		]
 	)
 
 	return result.txID
 }
 
-export async function getElectionVoterCount(proposalId: ProposalId): Promise<number> {
+export async function getElectionVoterCount(appId: number, proposalId: ProposalId): Promise<number> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const prefix = enc.encode('eb_')
 		const pidBytes = algosdk.bigIntToBytes(proposalId, 8)
 
@@ -82,17 +86,17 @@ export async function getElectionVoterCount(proposalId: ProposalId): Promise<num
 	}
 }
 
-export async function hasApprovalVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
-	return boxExists(approvalBallotKey(sender, proposalId))
+export async function hasApprovalVoted(appId: number, sender: Address, proposalId: ProposalId): Promise<boolean> {
+	return boxExists(appId, approvalBallotKey(sender, proposalId))
 }
 
-export async function hasElectionVoted(sender: Address, proposalId: ProposalId): Promise<boolean> {
-	return boxExists(electionBallotKey(sender, proposalId))
+export async function hasElectionVoted(appId: number, sender: Address, proposalId: ProposalId): Promise<boolean> {
+	return boxExists(appId, electionBallotKey(sender, proposalId))
 }
 
-export async function getElectionBallots(proposalId: ProposalId): Promise<number[][]> {
+export async function getElectionBallots(appId: number, proposalId: ProposalId): Promise<number[][]> {
 	try {
-		const { boxes } = await algodClient.getApplicationBoxes(APP_ID).do()
+		const { boxes } = await algodClient.getApplicationBoxes(appId).do()
 		const prefix = enc.encode('eb_')
 		const pidBytes = algosdk.bigIntToBytes(proposalId, 8)
 
@@ -104,7 +108,7 @@ export async function getElectionBallots(proposalId: ProposalId): Promise<number
 
 		return await Promise.all(
 			ballotBoxNames.map(async name => {
-				const box = await algodClient.getApplicationBoxByName(APP_ID, name).do()
+				const box = await algodClient.getApplicationBoxByName(appId, name).do()
 				return decodePreferenceOrder(box.value)
 			})
 		)
@@ -113,10 +117,14 @@ export async function getElectionBallots(proposalId: ProposalId): Promise<number
 	}
 }
 
-export async function getElectionBallotForVoter(address: Address, proposalId: ProposalId): Promise<number[] | null> {
+export async function getElectionBallotForVoter(
+	appId: number,
+	address: Address,
+	proposalId: ProposalId
+): Promise<number[] | null> {
 	try {
 		const key = electionBallotKey(address, proposalId)
-		const box = await algodClient.getApplicationBoxByName(APP_ID, key).do()
+		const box = await algodClient.getApplicationBoxByName(appId, key).do()
 		return decodePreferenceOrder(box.value)
 	} catch {
 		return null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,9 @@ services:
       - ./client:/client-out
       - shared-state:/shared
       - uv-cache:/root/.cache/uv
+      - contract-venv:/venv
     environment:
+      UV_PROJECT_ENVIRONMENT: "/venv"
       ALGOD_SERVER: "http://${ALGOD_HOST}"
       ALGOD_PORT: "${ALGOD_CONTAINER_PORT}"
       ALGOD_TOKEN: "${ALGO_TOKEN}"
@@ -99,7 +101,7 @@ services:
           echo "[contract-deploy] could not extract APP_ID from deploy log" >&2
           exit 1
         fi
-        echo "[contract-deploy] APP_ID=$$APP_ID — writing /client-out/.env.local"
+        echo "[contract-deploy] APP_ID=$$APP_ID - writing /client-out/.env.local"
         echo "VITE_APP_ID=$$APP_ID" > /client-out/.env.local
         echo "[contract-deploy] writing /shared/algorand.env"
         echo "DEMOCHAIN_APP_ID=$$APP_ID" > /shared/algorand.env
@@ -320,3 +322,4 @@ volumes:
   anchoring-pip-cache:
   shared-state:
   heartbeat-pip-cache:
+  contract-venv:


### PR DESCRIPTION
## Descripció del canvi

Substitueix la variable global mutable `APP_ID` per injecció de dependències: totes les funcions del client Algorand passen a rebre l'`appId` com a paràmetre explícit, i s'introdueix DemochainClient com a punt d'entrada únic.
  
El canvi elimina la necessitat de `setAppIdForTest` i l'estat global compartit entre tests, fent el codi més predictible i les instàncies del client independents entre si.

## Tipus de canvi

- [ ] `feat` — Nova funcionalitat
- [x] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [x] `refactor` — Refactorització (no canvia funcionalitat)
- [x] `test` — Tests
- [ ] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #536 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
