### PR TITLE
build(.githooks): executa tests de tots els stacks al pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,4 +49,61 @@ if [[ -n "$staged_ts" ]]; then
   fi
 fi
 
+# --- Tests Python (voting-contract/) ---
+if [[ -d "voting-contract" ]]; then
+  if ! command -v uv &>/dev/null; then
+    echo "⚠️  uv no trobat - saltant els tests de Python."
+  elif [[ -d "voting-contract/.venv" ]] && [[ "$(stat -c '%U' voting-contract/.venv 2>/dev/null)" == "root" ]]; then
+    echo "⚠️  voting-contract/.venv és propietat de root (creat per Docker)."
+    echo "   Executa: sudo rm -rf voting-contract/.venv"
+    failed=1
+  else
+    echo "🧪 Executant tests Python (algopy_testing)..."
+    if ! (cd voting-contract && uv run pytest tests -q --tb=short 2>&1); then
+      echo "❌ Tests Python han fallat."
+      failed=1
+    fi
+  fi
+fi
+
+# --- Tests client (Bun) ---
+if [[ -d "client" ]]; then
+  if ! command -v bun &>/dev/null; then
+    echo "⚠️  bun no trobat - saltant els tests del client."
+  else
+    if curl -sf http://localhost:4001/health &>/dev/null; then
+      echo "🧪 Executant tots els tests del client (LocalNet disponible)..."
+      if ! (cd client && bun test --reporter=dot 2>&1); then
+        echo "❌ Tests del client han fallat."
+        failed=1
+      fi
+    else
+      echo "⚠️  LocalNet no disponible - executant només tests unitaris del client."
+      if ! (cd client && bun test src/algorand/_contract.test.ts src/algorand/queries.test.ts --reporter=dot 2>&1); then
+        echo "❌ Tests unitaris del client han fallat."
+        failed=1
+      fi
+    fi
+  fi
+fi
+
+# --- Tests Ethereum (Hardhat) ---
+if [[ -d "network/ethereum" ]]; then
+  # Carrega NVM si node no és al PATH
+  if ! command -v npm &>/dev/null && [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+    source "$HOME/.nvm/nvm.sh" --no-use 2>/dev/null
+  fi
+
+  if ! command -v npm &>/dev/null; then
+    echo "⚠️  npm no trobat - saltant els tests d'Ethereum."
+    echo "   Instal·la Node.js o afegeix-lo al PATH."
+  else
+    echo "🧪 Executant tests Ethereum (Hardhat)..."
+    if ! (cd network/ethereum && npm test --silent 2>&1); then
+      echo "❌ Tests Ethereum han fallat."
+      failed=1
+    fi
+  fi
+fi
+
 exit $failed


### PR DESCRIPTION
## Descripció del canvi

Estén el *hook* `.githooks/pre-commit` perquè executi els tests dels tres *stacks* del *monorepo* (Python via uv run pytest, client via bun test i Ethereum via Hardhat) a més del *linting* ja existent. Per al client, detecta si el LocalNet està disponible i executa el *suite* complet o només els tests unitaris en conseqüència. Garanteix que cap *commit* rompi els tests de cap *stack* sense necessitat de passar per CI.

## Tipus de canvi

- [x] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [x] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #561 

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
