### PR TITLE
build(github): afegeix CODEOWNERS amb resvisors globals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners — review required on every PR
+* @jvanyom @tcontesti @linkcla @dylanluigi


### PR DESCRIPTION
## Descripció del canvi

Afegeix el fitxer `.github/CODEOWNERS` que assigna `@jvanyom`, `@tcontesti`, `@linkcla` i `@dylanluigi` com a revisors globals del repositori. A partir d'ara, GitHub els demanarà automàticament com a revisors en cada PR oberta.

## Tipus de canvi

- [ ] `feat` — Nova funcionalitat
- [ ] `fix` — Correcció d'error
- [ ] `docs` — Documentació
- [ ] `refactor` — Refactorització (no canvia funcionalitat)
- [ ] `test` — Tests
- [x] `chore` — Manteniment, deps, CI

## Issues relacionades

Closes #84

## Llista de verificació

- [x] He revisat el meu propi codi
- [x] El títol del PR segueix el format Conventional Commits (`type(scope): descripció`)
- [x] He executat `make lint` i passa sense errors
- [x] La documentació s'ha actualitzat si cal
